### PR TITLE
This commit fixes a bug that caused the application to crash during b…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -111,10 +111,16 @@ class MainWindow(QMainWindow):
             # Групуємо дані по номеру замовлення
             grouped = self.packing_list_df.groupby('Order_Number')
 
+            unnamed_counter = 1
             for order_number, group in grouped:
                 # Генерація баркоду
                 # Замінюємо символи, що не підходять для назв файлів
                 safe_order_number = "".join(c for c in order_number if c.isalnum() or c in ('-', '_')).rstrip()
+
+                if not safe_order_number:
+                    safe_order_number = f"unnamed_order_{unnamed_counter}"
+                    unnamed_counter += 1
+
                 barcode_path = os.path.join(self.barcode_dir, f"{safe_order_number}.png")
                 bc = code128(order_number, writer=ImageWriter())
                 bc.write(barcode_path)


### PR DESCRIPTION
…arcode generation if an order number consisted only of special characters.

The sanitization logic, which prepares the order number to be used as a filename, would produce an empty string in such cases, leading to a file creation error.

The fix adds a check to the `generate_barcodes_and_process_orders` method in `src/main.py`. If the sanitized order number is empty, a fallback unique name (e.g., "unnamed_order_1") is assigned to it, allowing the barcode generation to proceed without crashing. This makes the application more robust to varied data formats in the input file.