### PR TITLE
This commit resolves a persistent bug that caused barcode generation …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ numpy==2.3.3
 openpyxl==3.1.5
 packaging==25.0
 pandas==2.3.2
+pillow==11.3.0
 playwright==1.54.0
 pyee==13.0.0
 pyinstaller==6.16.0


### PR DESCRIPTION
…to fail.

The root cause was identified as a missing optional dependency for the `python-barcode` library. The `ImageWriter` used to create `.png` files for barcodes requires the `Pillow` library, which was not included in the project's dependencies.

This commit adds `Pillow` to `requirements.txt`, ensuring that the image writing functionality will work correctly in all environments, including the GitHub Actions build runner.