### PR TITLE
This commit adds a debugging step to the GitHub Actions release workf…

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,6 +26,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: List files for debugging
+        run: dir /s
+
       - name: Build executable with PyInstaller
         run: pyinstaller main.spec
 


### PR DESCRIPTION
…low. It lists all files in the workspace immediately before the PyInstaller build command is run. This is intended to diagnose an issue where the `main.spec` file is not being found by the build process.