### PR TITLE
This commit fixes the command in the debugging step of the release wo…

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,7 +27,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: List files for debugging
-        run: dir /s
+        run: Get-ChildItem -Recurse
 
       - name: Build executable with PyInstaller
         run: pyinstaller main.spec


### PR DESCRIPTION
…rkflow. The previous command (`dir /s`) was incorrect for the PowerShell environment used by Windows runners.

It has been replaced with `Get-ChildItem -Recurse`, which is the correct PowerShell equivalent for listing files recursively. This will allow the collection of debugging information to diagnose the `main.spec not found` error.