### PR TITLE
Fix(packer_logic): Disable text on barcodes to prevent rendering errors

### DIFF
--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -67,7 +67,7 @@ class PackerLogic:
                 barcode_path = os.path.join(self.barcode_dir, f"{safe_barcode_content}.png")
                 bc = code128(safe_barcode_content, writer=ImageWriter())
                 with open(barcode_path, 'wb') as f:
-                    bc.write(f)
+                    bc.write(f, options={'write_text': False})
 
                 self.orders_data[order_number] = {
                     'barcode_path': barcode_path,


### PR DESCRIPTION
The application was failing with a 'cannot open resource' error during barcode generation. This was caused by the rendering engine being unable to find a default font file to write the text below the barcode.

This fix disables text rendering on the barcode image, which prevents the font loading error and allows the barcode to be generated successfully. This is an effective workaround for environments where system fonts are not accessible.