### PR TITLE
fix: Prevent session from ending after column mapping

### DIFF
--- a/src/mapping_dialog.py
+++ b/src/mapping_dialog.py
@@ -1,5 +1,5 @@
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QComboBox, QPushButton, QDialogButtonBox
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QComboBox, QPushButton, QDialogButtonBox, QMessageBox
 )
 
 class ColumnMappingDialog(QDialog):
@@ -32,14 +32,28 @@ class ColumnMappingDialog(QDialog):
 
         # OK and Cancel buttons
         button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        button_box.accepted.connect(self.accept)
+        button_box.accepted.connect(self.validate_and_accept)
         button_box.rejected.connect(self.reject)
         layout.addWidget(button_box)
 
-    def get_mapping(self):
-        """Returns the mapping dictionary selected by the user."""
+    def validate_and_accept(self):
+        """Validates that all required columns are mapped before accepting."""
+        self.mapping = {}
+        unmapped_columns = []
         for req_col, combo in self.combo_boxes.items():
             selected_col = combo.currentText()
             if selected_col:
                 self.mapping[req_col] = selected_col
+            else:
+                unmapped_columns.append(req_col)
+
+        if unmapped_columns:
+            msg = "All required fields must be mapped.\nPlease map the following columns:\n\n"
+            msg += "\n".join(unmapped_columns)
+            QMessageBox.warning(self, "Incomplete Mapping", msg)
+        else:
+            self.accept()
+
+    def get_mapping(self):
+        """Returns the mapping dictionary selected by the user."""
         return self.mapping


### PR DESCRIPTION
This commit fixes a bug where the session would end prematurely if the user provided an incomplete column mapping in the `ColumnMappingDialog`.

The dialog now validates that all required columns have been mapped before it can be accepted. If any mappings are missing, a warning message is displayed to the user, and the dialog remains open, preventing an invalid state from being passed to the application logic.

This ensures a more robust and user-friendly workflow, preventing the application from entering an error state that would cause the session to terminate unexpectedly.