### PR TITLE
fix: Prevent focus loss in packer mode table

### DIFF
--- a/src/packer_mode_widget.py
+++ b/src/packer_mode_widget.py
@@ -1,7 +1,7 @@
 from functools import partial
 from PySide6.QtWidgets import (
     QWidget, QHBoxLayout, QVBoxLayout, QTableWidget, QTableWidgetItem,
-    QLabel, QLineEdit, QHeaderView, QPushButton
+    QLabel, QLineEdit, QHeaderView, QPushButton, QAbstractItemView
 )
 from PySide6.QtGui import QFont, QColor
 from PySide6.QtCore import Qt, Signal
@@ -23,6 +23,8 @@ class PackerModeWidget(QWidget):
         self.table.setHorizontalHeaderLabels(["Product Name", "SKU", "Packed / Required", "Status", "Action"])
         self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         self.table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.table.setSelectionMode(QAbstractItemView.NoSelection)
+        self.table.setFocusPolicy(Qt.NoFocus)
         left_layout.addWidget(self.table)
 
         right_widget = QWidget()


### PR DESCRIPTION
This commit resolves an issue where clicking on a cell in the packer mode's item table would steal focus from the hidden scanner input, preventing subsequent hardware scans.

The `QTableWidget` is now configured to be non-interactive:
- `setSelectionMode(QAbstractItemView.NoSelection)` prevents cells from being selected.
- `setFocusPolicy(Qt.NoFocus)` prevents the table itself from receiving keyboard focus.

This makes the table view passive, ensuring that focus always remains with the scanner input field unless a specific button (like 'Confirm Manually') is clicked. The logic to return focus after a button click remains in place, providing a robust solution to the focus problem.