### PR TITLE
fix: Correct QStyle enum for standard icons

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -91,12 +91,12 @@ class MainWindow(QMainWindow):
         main_layout.addWidget(control_panel)
 
         self.start_session_button = QPushButton("Start Session")
-        self.start_session_button.setIcon(self.style().standardIcon(QStyle.SP_MediaPlay))
+        self.start_session_button.setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_MediaPlay))
         self.start_session_button.clicked.connect(self.start_session)
         control_layout.addWidget(self.start_session_button)
 
         self.end_session_button = QPushButton("End Session")
-        self.end_session_button.setIcon(self.style().standardIcon(QStyle.SP_MediaStop))
+        self.end_session_button.setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_MediaStop))
         self.end_session_button.setEnabled(False)
         self.end_session_button.clicked.connect(self.end_session)
         control_layout.addWidget(self.end_session_button)
@@ -104,13 +104,13 @@ class MainWindow(QMainWindow):
         control_layout.addStretch()
 
         self.print_button = QPushButton("Print Barcodes")
-        self.print_button.setIcon(self.style().standardIcon(QStyle.SP_FilePrint))
+        self.print_button.setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_FilePrint))
         self.print_button.setEnabled(False)
         self.print_button.clicked.connect(self.open_print_dialog)
         control_layout.addWidget(self.print_button)
 
         self.packer_mode_button = QPushButton("Switch to Packer Mode")
-        self.packer_mode_button.setIcon(self.style().standardIcon(QStyle.SP_ArrowRight))
+        self.packer_mode_button.setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_ArrowRight))
         self.packer_mode_button.setEnabled(False)
         self.packer_mode_button.clicked.connect(self.switch_to_packer_mode)
         control_layout.addWidget(self.packer_mode_button)


### PR DESCRIPTION
This commit fixes a runtime `AttributeError` caused by incorrect access to the standard pixmap enums in `QStyle`.

The calls to `self.style().standardIcon(...)` were using `QStyle.SP_...` which is incorrect. The correct path is `QStyle.StandardPixmap.SP_...`. This has been corrected for all icons set in `MainWindow._init_ui`.