### PR TITLE
fix: Add missing QLineEdit import

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@ import os
 import json
 from PySide6.QtWidgets import (
     QApplication, QMainWindow, QLabel, QPushButton, QVBoxLayout, QWidget, QFileDialog, QStackedWidget,
-    QTableView, QHBoxLayout, QMessageBox, QHeaderView
+    QTableView, QHBoxLayout, QMessageBox, QHeaderView, QLineEdit
 )
 from PySide6.QtCore import QTimer, QUrl, Qt
 from PySide6.QtMultimedia import QSoundEffect


### PR DESCRIPTION
This commit fixes a `NameError` that occurred on startup due to a missing import for the `QLineEdit` class in `src/main.py`.

The class was used to create the new search input field, but its import was accidentally omitted during previous refactoring. This has been corrected.