### PR TITLE
Fix(packer): Correctly handle duplicate SKUs in a single order

### DIFF
--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -271,7 +271,7 @@ class PackerLogic(QObject):
         if original_order_number in self.session_packing_state['in_progress']:
             self.current_order_state = self.session_packing_state['in_progress'][original_order_number]
         else:
-            self.current_order_state = {}
+            self.current_order_state = []
             for i, item in enumerate(items):
                 sku = item.get('SKU')
                 if not sku: continue
@@ -279,10 +279,15 @@ class PackerLogic(QObject):
                     quantity = int(float(item.get('Quantity', 0)))
                 except (ValueError, TypeError):
                     quantity = 1
+
                 normalized_sku = self._normalize_sku(sku)
-                self.current_order_state[normalized_sku] = {
-                    'original_sku': sku, 'required': quantity, 'packed': 0, 'row': i
-                }
+                self.current_order_state.append({
+                    'original_sku': sku,
+                    'normalized_sku': normalized_sku,
+                    'required': quantity,
+                    'packed': 0,
+                    'row': i
+                })
             self.session_packing_state['in_progress'][original_order_number] = self.current_order_state
             self._save_session_state()
 
@@ -318,30 +323,39 @@ class PackerLogic(QObject):
         # The rest of the logic uses the potentially translated SKU.
         normalized_final_sku = self._normalize_sku(final_sku)
 
-        if normalized_final_sku in self.current_order_state:
-            state = self.current_order_state[normalized_final_sku]
-            if state['packed'] < state['required']:
-                state['packed'] += 1
-                is_complete = state['packed'] == state['required']
-                self.session_packing_state['in_progress'][self.current_order_number] = self.current_order_state
+        # Find the first matching item that is not yet fully packed
+        found_item = None
+        for item_state in self.current_order_state:
+            if item_state['normalized_sku'] == normalized_final_sku and item_state['packed'] < item_state['required']:
+                found_item = item_state
+                break
 
-                all_items_complete = all(s['packed'] == s['required'] for s in self.current_order_state.values())
+        if found_item:
+            found_item['packed'] += 1
+            is_complete = found_item['packed'] == found_item['required']
+            self.session_packing_state['in_progress'][self.current_order_number] = self.current_order_state
 
-                if all_items_complete:
-                    status = "ORDER_COMPLETE"
-                    del self.session_packing_state['in_progress'][self.current_order_number]
-                    if self.current_order_number not in self.session_packing_state['completed_orders']:
-                        self.session_packing_state['completed_orders'].append(self.current_order_number)
-                else:
-                    status = "SKU_OK"
-                    total_packed = sum(s['packed'] for s in self.current_order_state.values())
-                    total_required = sum(s['required'] for s in self.current_order_state.values())
-                    self.item_packed.emit(self.current_order_number, total_packed, total_required)
+            all_items_complete = all(s['packed'] == s['required'] for s in self.current_order_state)
 
-                self._save_session_state()
-                return {"row": state['row'], "packed": state['packed'], "is_complete": is_complete}, status
+            if all_items_complete:
+                status = "ORDER_COMPLETE"
+                del self.session_packing_state['in_progress'][self.current_order_number]
+                if self.current_order_number not in self.session_packing_state['completed_orders']:
+                    self.session_packing_state['completed_orders'].append(self.current_order_number)
             else:
-                return None, "SKU_EXTRA"
+                status = "SKU_OK"
+                total_packed = sum(s['packed'] for s in self.current_order_state)
+                total_required = sum(s['required'] for s in self.current_order_state)
+                self.item_packed.emit(self.current_order_number, total_packed, total_required)
+
+            self._save_session_state()
+            return {"row": found_item['row'], "packed": found_item['packed'], "is_complete": is_complete}, status
+
+        # If no item was found above, it might be because all matching SKUs are already packed.
+        # Let's check for that to return the correct status.
+        is_sku_in_order = any(s['normalized_sku'] == normalized_final_sku for s in self.current_order_state)
+        if is_sku_in_order:
+            return None, "SKU_EXTRA"  # All items with this SKU are already packed
         else:
             return None, "SKU_NOT_FOUND"
 

--- a/tests/test_packer_logic.py
+++ b/tests/test_packer_logic.py
@@ -182,7 +182,7 @@ class TestPackerLogic(unittest.TestCase):
 
         self.logic.start_order_packing('1001')
         # The logic should treat 'invalid_string' as a quantity of 1
-        self.assertEqual(self.logic.current_order_state['a1']['required'], 1)
+        self.assertEqual(self.logic.current_order_state[0]['required'], 1)
 
         # Scan the item, should complete the order
         result, status = self.logic.process_sku_scan('A-1')
@@ -218,7 +218,7 @@ class TestPackerLogic(unittest.TestCase):
 
         self.logic.start_order_packing('1001')
         self.assertIsNotNone(self.logic.current_order_number)
-        self.assertNotEqual(self.logic.current_order_state, {})
+        self.assertNotEqual(self.logic.current_order_state, [])
 
         self.logic.clear_current_order()
         self.assertIsNone(self.logic.current_order_number)
@@ -238,10 +238,66 @@ class TestPackerLogic(unittest.TestCase):
         self.logic.process_data_and_generate_barcodes()
 
         self.logic.start_order_packing('1001')
-        # The state should only contain the valid SKU, keyed by its normalized form
-        self.assertIn('a1', self.logic.current_order_state)
-        self.assertNotIn('', self.logic.current_order_state)
+        # The state should only contain the valid SKU
         self.assertEqual(len(self.logic.current_order_state), 1)
+        self.assertEqual(self.logic.current_order_state[0]['normalized_sku'], 'a1')
+
+    def test_packing_with_duplicate_sku_rows(self):
+        """Test packing an order with duplicate SKUs as separate rows."""
+        dummy_data = {
+            'Order_Number': ['ORD-001', 'ORD-001', 'ORD-001'],
+            'SKU': ['SKU-A', 'SKU-B', 'SKU-A'],
+            'Product_Name': ['Product A', 'Product B', 'Product A'],
+            'Quantity': [1, 2, 1],
+            'Courier': ['CourierX', 'CourierX', 'CourierX']
+        }
+        file_path = self._create_dummy_excel(dummy_data)
+        self.logic.load_packing_list_from_file(file_path)
+        self.logic.process_data_and_generate_barcodes()
+
+        # Start packing the order
+        items, status = self.logic.start_order_packing('ORD-001')
+        self.assertEqual(status, "ORDER_LOADED")
+        self.assertEqual(len(items), 3)
+        self.assertEqual(len(self.logic.current_order_state), 3)
+
+        # Scan the first SKU-A
+        result, status = self.logic.process_sku_scan('SKU-A')
+        self.assertEqual(status, "SKU_OK")
+        self.assertEqual(result['row'], 0) # First row with SKU-A
+        self.assertEqual(result['packed'], 1)
+        self.assertTrue(result['is_complete'])
+        self.assertEqual(self.logic.current_order_state[0]['packed'], 1)
+        self.assertEqual(self.logic.current_order_state[2]['packed'], 0) # The other SKU-A is untouched
+
+        # Scan SKU-B
+        result, status = self.logic.process_sku_scan('SKU-B')
+        self.assertEqual(status, "SKU_OK")
+        self.assertEqual(result['row'], 1)
+        self.assertEqual(result['packed'], 1)
+        self.assertFalse(result['is_complete'])
+
+        # Scan the second SKU-A
+        result, status = self.logic.process_sku_scan('SKU-A')
+        self.assertEqual(status, "SKU_OK")
+        self.assertEqual(result['row'], 2) # Second row with SKU-A
+        self.assertEqual(result['packed'], 1)
+        self.assertTrue(result['is_complete'])
+        self.assertEqual(self.logic.current_order_state[2]['packed'], 1)
+
+        # Scan the second SKU-B
+        result, status = self.logic.process_sku_scan('SKU-B')
+        self.assertEqual(status, "ORDER_COMPLETE")
+        self.assertEqual(result['row'], 1)
+        self.assertEqual(result['packed'], 2)
+        self.assertTrue(result['is_complete'])
+
+        # Check order is marked as complete
+        self.assertIn('ORD-001', self.logic.session_packing_state['completed_orders'])
+
+        # Test extra scan
+        result, status = self.logic.process_sku_scan('SKU-A')
+        self.assertEqual(status, "SKU_EXTRA")
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Refactored the data structure for the current order state from a dictionary to a list of dictionaries. This resolves a bug where multiple line items with the same SKU in an order would overwrite each other, making it impossible to complete packing.

- Modified `start_order_packing` to initialize `current_order_state` as a list, preserving each line item uniquely.
- Updated `process_sku_scan` to iterate through the list and find the first available (unpackaged) item matching the scanned SKU.
- Adjusted existing unit tests to be compatible with the new list-based data structure.
- Added a new unit test `test_packing_with_duplicate_sku_rows` to specifically verify the fix for the duplicate SKU scenario.
- All tests now pass, confirming the fix and ensuring no regressions were introduced.