### PR TITLE
fix(phase-1.2): Fix import paths and PyInstaller configuration

### DIFF
--- a/main.spec
+++ b/main.spec
@@ -3,14 +3,22 @@
 
 a = Analysis(
     ['src/main.py'],
-    pathex=[],
+    pathex=['src'],
     binaries=[],
     datas=[
         ('sounds', 'sounds'),
         ('src/styles.qss', 'src'),
         ('config.ini.example', '.'),
     ],
-    hiddenimports=[],
+    hiddenimports=[
+        'exceptions',
+        'session_lock_manager',
+        'restore_session_dialog',
+        'session_monitor_widget',
+        'logger',
+        'profile_manager',
+        'session_manager',
+    ],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/src/session_lock_manager.py
+++ b/src/session_lock_manager.py
@@ -16,8 +16,8 @@ from typing import Dict, Optional, Tuple
 import shutil
 import tempfile
 
-from src.logger import AppLogger
-from src.exceptions import SessionLockedError, StaleLockError
+from logger import AppLogger
+from exceptions import SessionLockedError, StaleLockError
 
 
 class SessionLockManager:

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from typing import Optional
 
 from logger import get_logger
-from src.exceptions import SessionLockedError, StaleLockError
+from exceptions import SessionLockedError, StaleLockError
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
Fixed Issues:
- Removed 'src.' prefix from imports in session_lock_manager.py
- Removed 'src.' prefix from imports in session_manager.py
- Added pathex=['src'] to main.spec for proper module resolution
- Added new modules to hiddenimports in main.spec

Changes:
- session_lock_manager.py: from src.logger -> from logger
- session_lock_manager.py: from src.exceptions -> from exceptions
- session_manager.py: from src.exceptions -> from exceptions
- main.spec: Added pathex=['src']
- main.spec: Added hiddenimports for new Phase 1.2 modules

This fixes the ModuleNotFoundError when running the built executable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)