### PR TITLE
Add Shopify session integration to packing tool

### DIFF
--- a/src/session_selector.py
+++ b/src/session_selector.py
@@ -1,0 +1,451 @@
+"""
+Session Selector Widget - Choose Shopify sessions to pack.
+
+This module provides a UI widget for selecting Shopify Tool sessions
+to load into Packing Tool. It displays available sessions with metadata
+such as order count and allows filtering by date.
+
+Integration with Shopify Tool (Phase 1.3.2):
+- Scans Sessions/CLIENT_{ID}/ directories
+- Looks for sessions with analysis/analysis_data.json
+- Displays session info (date, orders count)
+- Returns selected session path for loading
+"""
+
+from pathlib import Path
+from datetime import datetime
+from typing import Optional, List, Dict
+import json
+
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QComboBox,
+    QListWidget, QListWidgetItem, QPushButton, QDateEdit,
+    QCheckBox, QMessageBox, QGroupBox
+)
+from PySide6.QtCore import Qt, QDate
+
+from logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class SessionSelectorDialog(QDialog):
+    """
+    Dialog for selecting a Shopify session to load for packing.
+
+    Displays:
+    - Client selector dropdown
+    - List of available Shopify sessions
+    - Session metadata (date, orders count)
+    - Date range filter
+
+    Returns:
+    - Selected session path (Path object)
+    - Session metadata dictionary
+    """
+
+    def __init__(self, profile_manager, parent=None):
+        """
+        Initialize SessionSelectorDialog.
+
+        Args:
+            profile_manager: ProfileManager instance for accessing sessions
+            parent: Parent widget
+        """
+        super().__init__(parent)
+
+        self.profile_manager = profile_manager
+        self.selected_session_path = None
+        self.selected_session_data = None
+
+        self.setWindowTitle("Select Shopify Session to Pack")
+        self.setMinimumWidth(700)
+        self.setMinimumHeight(500)
+
+        self._init_ui()
+        self._load_clients()
+
+        logger.info("SessionSelectorDialog initialized")
+
+    def _init_ui(self):
+        """Initialize user interface components."""
+        layout = QVBoxLayout(self)
+
+        # ====================================================================
+        # CLIENT SELECTION
+        # ====================================================================
+        client_group = QGroupBox("Select Client")
+        client_layout = QHBoxLayout(client_group)
+
+        client_label = QLabel("Client:")
+        client_layout.addWidget(client_label)
+
+        self.client_combo = QComboBox()
+        self.client_combo.setMinimumWidth(200)
+        self.client_combo.currentIndexChanged.connect(self._on_client_changed)
+        client_layout.addWidget(self.client_combo)
+
+        client_layout.addStretch()
+        layout.addWidget(client_group)
+
+        # ====================================================================
+        # FILTER OPTIONS
+        # ====================================================================
+        filter_group = QGroupBox("Filter Sessions")
+        filter_layout = QHBoxLayout(filter_group)
+
+        # Date range filter
+        self.use_date_filter_checkbox = QCheckBox("Filter by date range:")
+        self.use_date_filter_checkbox.stateChanged.connect(self._refresh_sessions)
+        filter_layout.addWidget(self.use_date_filter_checkbox)
+
+        filter_layout.addWidget(QLabel("From:"))
+        self.date_from = QDateEdit()
+        self.date_from.setCalendarPopup(True)
+        self.date_from.setDate(QDate.currentDate().addDays(-30))
+        self.date_from.dateChanged.connect(self._refresh_sessions)
+        filter_layout.addWidget(self.date_from)
+
+        filter_layout.addWidget(QLabel("To:"))
+        self.date_to = QDateEdit()
+        self.date_to.setCalendarPopup(True)
+        self.date_to.setDate(QDate.currentDate())
+        self.date_to.dateChanged.connect(self._refresh_sessions)
+        filter_layout.addWidget(self.date_to)
+
+        # Show only sessions with Shopify data
+        self.shopify_only_checkbox = QCheckBox("Shopify sessions only")
+        self.shopify_only_checkbox.setChecked(True)
+        self.shopify_only_checkbox.stateChanged.connect(self._refresh_sessions)
+        filter_layout.addWidget(self.shopify_only_checkbox)
+
+        filter_layout.addStretch()
+        layout.addWidget(filter_group)
+
+        # ====================================================================
+        # SESSIONS LIST
+        # ====================================================================
+        sessions_group = QGroupBox("Available Sessions")
+        sessions_layout = QVBoxLayout(sessions_group)
+
+        self.sessions_list = QListWidget()
+        self.sessions_list.itemDoubleClicked.connect(self._on_session_double_clicked)
+        sessions_layout.addWidget(self.sessions_list)
+
+        layout.addWidget(sessions_group)
+
+        # ====================================================================
+        # SESSION INFO
+        # ====================================================================
+        info_group = QGroupBox("Session Details")
+        info_layout = QVBoxLayout(info_group)
+
+        self.info_label = QLabel("Select a session to see details")
+        self.info_label.setWordWrap(True)
+        info_layout.addWidget(self.info_label)
+
+        layout.addWidget(info_group)
+
+        # ====================================================================
+        # BUTTONS
+        # ====================================================================
+        button_layout = QHBoxLayout()
+
+        self.load_button = QPushButton("Load Session")
+        self.load_button.setEnabled(False)
+        self.load_button.clicked.connect(self._on_load_clicked)
+        button_layout.addWidget(self.load_button)
+
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.reject)
+        button_layout.addWidget(self.cancel_button)
+
+        button_layout.addStretch()
+        layout.addLayout(button_layout)
+
+        # Connect selection change
+        self.sessions_list.itemSelectionChanged.connect(self._on_session_selected)
+
+    def _load_clients(self):
+        """Load available clients from ProfileManager."""
+        logger.info("Loading available clients")
+
+        self.client_combo.blockSignals(True)
+        self.client_combo.clear()
+
+        try:
+            clients = self.profile_manager.get_available_clients()
+
+            if not clients:
+                logger.warning("No clients found")
+                self.client_combo.addItem("(No clients available)", None)
+                self.client_combo.setEnabled(False)
+                return
+
+            self.client_combo.setEnabled(True)
+
+            for client_id in clients:
+                config = self.profile_manager.load_client_config(client_id)
+                if config:
+                    display_name = f"{config.get('client_name', client_id)} ({client_id})"
+                else:
+                    display_name = client_id
+
+                self.client_combo.addItem(display_name, client_id)
+
+            logger.info(f"Loaded {len(clients)} clients")
+
+        except Exception as e:
+            logger.error(f"Error loading clients: {e}", exc_info=True)
+            QMessageBox.warning(self, "Error", f"Failed to load clients:\n\n{e}")
+
+        finally:
+            self.client_combo.blockSignals(False)
+
+        # Trigger loading sessions for first client
+        if self.client_combo.count() > 0 and self.client_combo.currentData():
+            self._on_client_changed(0)
+
+    def _on_client_changed(self, index: int):
+        """Handle client selection change."""
+        client_id = self.client_combo.currentData()
+
+        if not client_id:
+            logger.debug("No valid client selected")
+            return
+
+        logger.info(f"Client changed to: {client_id}")
+        self._refresh_sessions()
+
+    def _refresh_sessions(self):
+        """Refresh sessions list for current client with filters."""
+        client_id = self.client_combo.currentData()
+
+        if not client_id:
+            return
+
+        logger.info(f"Refreshing sessions for client {client_id}")
+
+        self.sessions_list.clear()
+        self.info_label.setText("Select a session to see details")
+        self.load_button.setEnabled(False)
+
+        try:
+            # Get all sessions for client
+            sessions = self._scan_shopify_sessions(client_id)
+
+            # Apply filters
+            if self.use_date_filter_checkbox.isChecked():
+                sessions = self._filter_by_date(sessions)
+
+            if self.shopify_only_checkbox.isChecked():
+                sessions = [s for s in sessions if s.get('has_shopify_data', False)]
+
+            logger.info(f"Found {len(sessions)} sessions after filtering")
+
+            # Populate list
+            for session in sessions:
+                item = QListWidgetItem()
+
+                # Format display text
+                session_name = session['name']
+                orders_count = session.get('orders_count', 0)
+                has_shopify = session.get('has_shopify_data', False)
+
+                display_text = f"{session_name}"
+                if has_shopify:
+                    display_text += f" - {orders_count} orders (Shopify)"
+                else:
+                    display_text += " - No Shopify data"
+
+                item.setText(display_text)
+                item.setData(Qt.UserRole, session)
+
+                # Color code by type
+                if has_shopify:
+                    item.setForeground(Qt.darkGreen)
+                else:
+                    item.setForeground(Qt.gray)
+
+                self.sessions_list.addItem(item)
+
+            if len(sessions) == 0:
+                info_item = QListWidgetItem("No sessions found for this client")
+                info_item.setForeground(Qt.gray)
+                self.sessions_list.addItem(info_item)
+
+        except Exception as e:
+            logger.error(f"Error refreshing sessions: {e}", exc_info=True)
+            QMessageBox.warning(self, "Error", f"Failed to load sessions:\n\n{e}")
+
+    def _scan_shopify_sessions(self, client_id: str) -> List[Dict]:
+        """
+        Scan for Shopify sessions in Sessions/CLIENT_{ID}/ directory.
+
+        A Shopify session is identified by:
+        - Has analysis/analysis_data.json file
+        - Created by Shopify Tool
+
+        Args:
+            client_id: Client identifier
+
+        Returns:
+            List of session dictionaries with metadata
+        """
+        sessions_dir = self.profile_manager.get_sessions_root() / f"CLIENT_{client_id}"
+
+        if not sessions_dir.exists():
+            logger.debug(f"No sessions directory for client {client_id}")
+            return []
+
+        sessions = []
+
+        try:
+            for session_dir in sessions_dir.iterdir():
+                if not session_dir.is_dir():
+                    continue
+
+                session_info = {
+                    'name': session_dir.name,
+                    'path': session_dir,
+                    'modified': datetime.fromtimestamp(session_dir.stat().st_mtime),
+                    'has_shopify_data': False,
+                    'orders_count': 0
+                }
+
+                # Check for Shopify data
+                analysis_data_path = session_dir / "analysis" / "analysis_data.json"
+
+                if analysis_data_path.exists():
+                    try:
+                        with open(analysis_data_path, 'r', encoding='utf-8') as f:
+                            analysis_data = json.load(f)
+
+                        session_info['has_shopify_data'] = True
+                        session_info['orders_count'] = analysis_data.get('total_orders', 0)
+                        session_info['analysis_data'] = analysis_data
+
+                        logger.debug(f"Found Shopify session: {session_dir.name} ({session_info['orders_count']} orders)")
+
+                    except Exception as e:
+                        logger.warning(f"Error reading analysis_data.json for {session_dir.name}: {e}")
+
+                sessions.append(session_info)
+
+            # Sort by modification time (newest first)
+            sessions.sort(key=lambda x: x['modified'], reverse=True)
+
+            return sessions
+
+        except Exception as e:
+            logger.error(f"Error scanning sessions: {e}", exc_info=True)
+            return []
+
+    def _filter_by_date(self, sessions: List[Dict]) -> List[Dict]:
+        """
+        Filter sessions by date range.
+
+        Args:
+            sessions: List of session dictionaries
+
+        Returns:
+            Filtered list of sessions
+        """
+        from_date = self.date_from.date().toPython()
+        to_date = self.date_to.date().toPython()
+
+        filtered = []
+        for session in sessions:
+            session_date = session['modified'].date()
+            if from_date <= session_date <= to_date:
+                filtered.append(session)
+
+        return filtered
+
+    def _on_session_selected(self):
+        """Handle session selection change."""
+        selected_items = self.sessions_list.selectedItems()
+
+        if not selected_items:
+            self.info_label.setText("Select a session to see details")
+            self.load_button.setEnabled(False)
+            return
+
+        item = selected_items[0]
+        session = item.data(Qt.UserRole)
+
+        if not session or not isinstance(session, dict):
+            return
+
+        # Update info label
+        info_text = f"<b>Session:</b> {session['name']}<br>"
+        info_text += f"<b>Modified:</b> {session['modified'].strftime('%Y-%m-%d %H:%M')}<br>"
+
+        if session.get('has_shopify_data'):
+            info_text += f"<b>Orders:</b> {session.get('orders_count', 0)}<br>"
+            info_text += f"<b>Type:</b> Shopify Session<br>"
+
+            # Show path to analysis data
+            analysis_path = session['path'] / "analysis" / "analysis_data.json"
+            info_text += f"<b>Data:</b> {analysis_path.name}"
+
+            self.load_button.setEnabled(True)
+        else:
+            info_text += "<b>Type:</b> Regular session (no Shopify data)"
+            self.load_button.setEnabled(False)
+
+        self.info_label.setText(info_text)
+
+    def _on_session_double_clicked(self, item: QListWidgetItem):
+        """Handle double-click on session (same as clicking Load)."""
+        session = item.data(Qt.UserRole)
+
+        if session and isinstance(session, dict) and session.get('has_shopify_data'):
+            self._on_load_clicked()
+
+    def _on_load_clicked(self):
+        """Handle Load button click."""
+        selected_items = self.sessions_list.selectedItems()
+
+        if not selected_items:
+            return
+
+        item = selected_items[0]
+        session = item.data(Qt.UserRole)
+
+        if not session or not isinstance(session, dict):
+            return
+
+        if not session.get('has_shopify_data'):
+            QMessageBox.warning(
+                self,
+                "Invalid Session",
+                "Selected session does not have Shopify data.\n"
+                "Please select a session created by Shopify Tool."
+            )
+            return
+
+        logger.info(f"Loading Shopify session: {session['name']}")
+
+        self.selected_session_path = session['path']
+        self.selected_session_data = session.get('analysis_data')
+
+        self.accept()
+
+    def get_selected_session(self) -> Optional[Path]:
+        """
+        Get selected session path.
+
+        Returns:
+            Path to selected session directory, or None if cancelled
+        """
+        return self.selected_session_path
+
+    def get_session_data(self) -> Optional[Dict]:
+        """
+        Get selected session's analysis data.
+
+        Returns:
+            Analysis data dictionary, or None if not available
+        """
+        return self.selected_session_data

--- a/tests/test_session_selector.py
+++ b/tests/test_session_selector.py
@@ -1,0 +1,313 @@
+"""
+Tests for SessionSelectorDialog - Shopify session selection widget.
+
+Tests cover:
+- Client loading from ProfileManager
+- Session scanning with Shopify data
+- Filtering by date range
+- Session selection and data retrieval
+"""
+
+import pytest
+import json
+from pathlib import Path
+from datetime import datetime, timedelta
+from unittest.mock import Mock, MagicMock, patch
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import QDate
+
+from src.session_selector import SessionSelectorDialog
+
+
+@pytest.fixture
+def qapp():
+    """Create QApplication instance for widget tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+@pytest.fixture
+def mock_profile_manager(tmp_path):
+    """Create mock ProfileManager with test data."""
+    manager = Mock()
+
+    # Mock paths
+    sessions_root = tmp_path / "Sessions"
+    sessions_root.mkdir()
+
+    manager.get_sessions_root.return_value = sessions_root
+    manager.get_available_clients.return_value = ["M", "A", "B"]
+
+    # Mock client configs
+    def load_client_config(client_id):
+        return {
+            "client_id": client_id,
+            "client_name": f"Client {client_id}"
+        }
+
+    manager.load_client_config.side_effect = load_client_config
+
+    return manager, sessions_root
+
+
+def create_test_session(sessions_dir: Path, client_id: str, session_name: str,
+                        has_shopify: bool = True, orders_count: int = 10):
+    """
+    Helper to create test session directory with optional Shopify data.
+
+    Args:
+        sessions_dir: Root sessions directory
+        client_id: Client identifier
+        session_name: Session directory name
+        has_shopify: Whether to create analysis_data.json
+        orders_count: Number of orders in analysis data
+    """
+    client_dir = sessions_dir / f"CLIENT_{client_id}"
+    client_dir.mkdir(exist_ok=True)
+
+    session_dir = client_dir / session_name
+    session_dir.mkdir()
+
+    if has_shopify:
+        analysis_dir = session_dir / "analysis"
+        analysis_dir.mkdir()
+
+        analysis_data = {
+            "analyzed_at": "2025-11-04T10:30:00",
+            "total_orders": orders_count,
+            "fulfillable_orders": orders_count,
+            "orders": [
+                {
+                    "order_number": f"ORDER-{i:03d}",
+                    "courier": "DHL",
+                    "status": "Fulfillable",
+                    "items": [
+                        {
+                            "sku": f"SKU-{i}",
+                            "quantity": 1,
+                            "product_name": f"Product {i}"
+                        }
+                    ]
+                }
+                for i in range(orders_count)
+            ]
+        }
+
+        analysis_file = analysis_dir / "analysis_data.json"
+        with open(analysis_file, 'w', encoding='utf-8') as f:
+            json.dump(analysis_data, f)
+
+    return session_dir
+
+
+class TestSessionSelectorDialog:
+    """Tests for SessionSelectorDialog widget."""
+
+    def test_init(self, qapp, mock_profile_manager):
+        """Test dialog initialization."""
+        manager, _ = mock_profile_manager
+
+        dialog = SessionSelectorDialog(manager)
+
+        assert dialog.windowTitle() == "Select Shopify Session to Pack"
+        assert dialog.profile_manager == manager
+        assert dialog.selected_session_path is None
+        assert dialog.selected_session_data is None
+
+    def test_load_clients(self, qapp, mock_profile_manager):
+        """Test loading clients into dropdown."""
+        manager, _ = mock_profile_manager
+
+        dialog = SessionSelectorDialog(manager)
+
+        # Should have 3 clients
+        assert dialog.client_combo.count() == 3
+
+        # Check client names
+        assert "Client M (M)" in dialog.client_combo.itemText(0)
+        assert "Client A (A)" in dialog.client_combo.itemText(1)
+        assert "Client B (B)" in dialog.client_combo.itemText(2)
+
+        # Check client data
+        assert dialog.client_combo.itemData(0) == "M"
+        assert dialog.client_combo.itemData(1) == "A"
+        assert dialog.client_combo.itemData(2) == "B"
+
+    def test_load_clients_empty(self, qapp):
+        """Test behavior when no clients available."""
+        manager = Mock()
+        manager.get_available_clients.return_value = []
+
+        dialog = SessionSelectorDialog(manager)
+
+        assert dialog.client_combo.count() == 1
+        assert "(No clients available)" in dialog.client_combo.itemText(0)
+        assert not dialog.client_combo.isEnabled()
+
+    def test_scan_shopify_sessions_with_data(self, qapp, mock_profile_manager):
+        """Test scanning sessions with Shopify data."""
+        manager, sessions_root = mock_profile_manager
+
+        # Create test sessions
+        create_test_session(sessions_root, "M", "2025-11-04_1", has_shopify=True, orders_count=10)
+        create_test_session(sessions_root, "M", "2025-11-03_1", has_shopify=True, orders_count=25)
+        create_test_session(sessions_root, "M", "2025-11-02_1", has_shopify=False)
+
+        dialog = SessionSelectorDialog(manager)
+
+        # Scan sessions for client M
+        sessions = dialog._scan_shopify_sessions("M")
+
+        # Should find 3 sessions
+        assert len(sessions) == 3
+
+        # Check Shopify sessions
+        shopify_sessions = [s for s in sessions if s['has_shopify_data']]
+        assert len(shopify_sessions) == 2
+
+        # Check orders counts
+        session_1 = next(s for s in sessions if s['name'] == "2025-11-04_1")
+        assert session_1['has_shopify_data'] is True
+        assert session_1['orders_count'] == 10
+
+        session_2 = next(s for s in sessions if s['name'] == "2025-11-03_1")
+        assert session_2['has_shopify_data'] is True
+        assert session_2['orders_count'] == 25
+
+        session_3 = next(s for s in sessions if s['name'] == "2025-11-02_1")
+        assert session_3['has_shopify_data'] is False
+
+    def test_scan_shopify_sessions_no_client_dir(self, qapp, mock_profile_manager):
+        """Test scanning when client has no sessions directory."""
+        manager, sessions_root = mock_profile_manager
+
+        dialog = SessionSelectorDialog(manager)
+
+        # Scan for non-existent client
+        sessions = dialog._scan_shopify_sessions("X")
+
+        assert len(sessions) == 0
+
+    def test_filter_by_date(self, qapp, mock_profile_manager):
+        """Test date range filtering."""
+        manager, _ = mock_profile_manager
+
+        dialog = SessionSelectorDialog(manager)
+
+        # Create test sessions with different dates
+        today = datetime.now()
+        yesterday = today - timedelta(days=1)
+        last_week = today - timedelta(days=7)
+
+        sessions = [
+            {'name': 'today', 'modified': today, 'has_shopify_data': True},
+            {'name': 'yesterday', 'modified': yesterday, 'has_shopify_data': True},
+            {'name': 'last_week', 'modified': last_week, 'has_shopify_data': True}
+        ]
+
+        # Set filter to last 3 days
+        dialog.date_from.setDate(QDate.currentDate().addDays(-3))
+        dialog.date_to.setDate(QDate.currentDate())
+
+        filtered = dialog._filter_by_date(sessions)
+
+        # Should include today and yesterday, but not last_week
+        assert len(filtered) == 2
+        assert filtered[0]['name'] == 'today'
+        assert filtered[1]['name'] == 'yesterday'
+
+    def test_session_selection(self, qapp, mock_profile_manager):
+        """Test session selection and data retrieval."""
+        manager, sessions_root = mock_profile_manager
+
+        # Create test session
+        session_dir = create_test_session(sessions_root, "M", "2025-11-04_1", has_shopify=True, orders_count=15)
+
+        dialog = SessionSelectorDialog(manager)
+
+        # Manually trigger session list population
+        dialog._refresh_sessions()
+
+        # Should have sessions in list
+        assert dialog.sessions_list.count() > 0
+
+        # Select first session
+        dialog.sessions_list.setCurrentRow(0)
+
+        # Info label should be updated
+        assert "2025-11-04_1" in dialog.info_label.text()
+        assert "15" in dialog.info_label.text()  # orders count
+
+        # Load button should be enabled
+        assert dialog.load_button.isEnabled()
+
+    def test_session_selection_without_shopify_data(self, qapp, mock_profile_manager):
+        """Test selecting session without Shopify data."""
+        manager, sessions_root = mock_profile_manager
+
+        # Create session without Shopify data
+        create_test_session(sessions_root, "M", "2025-11-04_1", has_shopify=False)
+
+        dialog = SessionSelectorDialog(manager)
+        dialog._refresh_sessions()
+
+        # Disable "Shopify only" filter to see all sessions
+        dialog.shopify_only_checkbox.setChecked(False)
+        dialog._refresh_sessions()
+
+        # Select session
+        dialog.sessions_list.setCurrentRow(0)
+
+        # Load button should be disabled (no Shopify data)
+        assert not dialog.load_button.isEnabled()
+
+    def test_get_selected_session(self, qapp, mock_profile_manager):
+        """Test getting selected session path and data."""
+        manager, sessions_root = mock_profile_manager
+
+        session_dir = create_test_session(sessions_root, "M", "2025-11-04_1", has_shopify=True, orders_count=20)
+
+        dialog = SessionSelectorDialog(manager)
+        dialog._refresh_sessions()
+
+        # Manually set selected session (simulating load button click)
+        sessions = dialog._scan_shopify_sessions("M")
+        session = sessions[0]
+
+        dialog.selected_session_path = session['path']
+        dialog.selected_session_data = session.get('analysis_data')
+
+        # Verify retrieved data
+        assert dialog.get_selected_session() == session_dir
+        assert dialog.get_session_data() is not None
+        assert dialog.get_session_data()['total_orders'] == 20
+
+    def test_shopify_filter_checkbox(self, qapp, mock_profile_manager):
+        """Test Shopify-only filter checkbox."""
+        manager, sessions_root = mock_profile_manager
+
+        # Create mixed sessions
+        create_test_session(sessions_root, "M", "2025-11-04_1", has_shopify=True, orders_count=10)
+        create_test_session(sessions_root, "M", "2025-11-03_1", has_shopify=False)
+
+        dialog = SessionSelectorDialog(manager)
+
+        # With filter enabled (default)
+        dialog.shopify_only_checkbox.setChecked(True)
+        dialog._refresh_sessions()
+
+        # Should show only Shopify sessions
+        assert dialog.sessions_list.count() == 1
+
+        # Disable filter
+        dialog.shopify_only_checkbox.setChecked(False)
+        dialog._refresh_sessions()
+
+        # Should show all sessions
+        assert dialog.sessions_list.count() == 2
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/tests/test_shopify_integration.py
+++ b/tests/test_shopify_integration.py
@@ -1,0 +1,359 @@
+"""
+Tests for Shopify Tool integration (Phase 1.3.2).
+
+Tests cover:
+- Loading analysis_data.json from Shopify sessions
+- Converting Shopify order format to packing list format
+- Barcode generation from Shopify data
+- Error handling for invalid/missing data
+"""
+
+import pytest
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+from src.packer_logic import PackerLogic
+
+
+@pytest.fixture
+def mock_profile_manager():
+    """Create mock ProfileManager."""
+    manager = Mock()
+    manager.load_sku_mapping.return_value = {}
+    return manager
+
+
+@pytest.fixture
+def barcode_dir(tmp_path):
+    """Create temporary barcode directory."""
+    barcodes = tmp_path / "barcodes"
+    barcodes.mkdir()
+    return str(barcodes)
+
+
+@pytest.fixture
+def shopify_session(tmp_path):
+    """Create test Shopify session with analysis_data.json."""
+    session_dir = tmp_path / "2025-11-04_1"
+    session_dir.mkdir()
+
+    analysis_dir = session_dir / "analysis"
+    analysis_dir.mkdir()
+
+    analysis_data = {
+        "analyzed_at": "2025-11-04T10:30:00",
+        "total_orders": 3,
+        "fulfillable_orders": 3,
+        "orders": [
+            {
+                "order_number": "ORDER-001",
+                "courier": "DHL",
+                "status": "Fulfillable",
+                "items": [
+                    {
+                        "sku": "SKU-123",
+                        "quantity": 2,
+                        "product_name": "Product A"
+                    },
+                    {
+                        "sku": "SKU-456",
+                        "quantity": 1,
+                        "product_name": "Product B"
+                    }
+                ]
+            },
+            {
+                "order_number": "ORDER-002",
+                "courier": "PostOne",
+                "status": "Fulfillable",
+                "items": [
+                    {
+                        "sku": "SKU-789",
+                        "quantity": 3,
+                        "product_name": "Product C"
+                    }
+                ]
+            },
+            {
+                "order_number": "ORDER-003",
+                "courier": "Speedy",
+                "status": "Fulfillable",
+                "items": [
+                    {
+                        "sku": "SKU-123",
+                        "quantity": 1,
+                        "product_name": "Product A"
+                    }
+                ]
+            }
+        ]
+    }
+
+    analysis_file = analysis_dir / "analysis_data.json"
+    with open(analysis_file, 'w', encoding='utf-8') as f:
+        json.dump(analysis_data, f, indent=2)
+
+    return session_dir, analysis_data
+
+
+class TestShopifyIntegration:
+    """Tests for Shopify Tool integration."""
+
+    def test_load_from_shopify_analysis_success(self, mock_profile_manager, barcode_dir, shopify_session):
+        """Test successful loading of Shopify session data."""
+        session_dir, expected_data = shopify_session
+
+        logic = PackerLogic(
+            client_id="TEST",
+            profile_manager=mock_profile_manager,
+            barcode_dir=barcode_dir
+        )
+
+        # Load from Shopify analysis
+        order_count, analyzed_at = logic.load_from_shopify_analysis(session_dir)
+
+        # Verify counts
+        assert order_count == 3
+        assert analyzed_at == "2025-11-04T10:30:00"
+
+        # Verify DataFrame was created
+        assert logic.packing_list_df is not None
+        assert logic.processed_df is not None
+
+        # Verify row count (3 items in ORDER-001, 1 in ORDER-002, 1 in ORDER-003 = 4 total rows)
+        assert len(logic.processed_df) == 4
+
+        # Verify columns
+        required_cols = ['Order_Number', 'SKU', 'Product_Name', 'Quantity', 'Courier']
+        for col in required_cols:
+            assert col in logic.processed_df.columns
+
+        # Verify data content
+        order_001_rows = logic.processed_df[logic.processed_df['Order_Number'] == 'ORDER-001']
+        assert len(order_001_rows) == 2
+        assert 'SKU-123' in order_001_rows['SKU'].values
+        assert 'SKU-456' in order_001_rows['SKU'].values
+
+        # Verify orders_data was populated
+        assert len(logic.orders_data) == 3
+        assert 'ORDER-001' in logic.orders_data
+        assert 'ORDER-002' in logic.orders_data
+        assert 'ORDER-003' in logic.orders_data
+
+        # Verify barcode mapping
+        assert len(logic.barcode_to_order_number) == 3
+
+    def test_load_from_shopify_analysis_file_not_found(self, mock_profile_manager, barcode_dir, tmp_path):
+        """Test error when analysis_data.json not found."""
+        session_dir = tmp_path / "empty_session"
+        session_dir.mkdir()
+
+        logic = PackerLogic(
+            client_id="TEST",
+            profile_manager=mock_profile_manager,
+            barcode_dir=barcode_dir
+        )
+
+        # Should raise ValueError
+        with pytest.raises(ValueError, match="analysis_data.json not found"):
+            logic.load_from_shopify_analysis(session_dir)
+
+    def test_load_from_shopify_analysis_invalid_json(self, mock_profile_manager, barcode_dir, tmp_path):
+        """Test error when analysis_data.json contains invalid JSON."""
+        session_dir = tmp_path / "invalid_session"
+        session_dir.mkdir()
+
+        analysis_dir = session_dir / "analysis"
+        analysis_dir.mkdir()
+
+        # Write invalid JSON
+        analysis_file = analysis_dir / "analysis_data.json"
+        with open(analysis_file, 'w') as f:
+            f.write("{ invalid json }")
+
+        logic = PackerLogic(
+            client_id="TEST",
+            profile_manager=mock_profile_manager,
+            barcode_dir=barcode_dir
+        )
+
+        # Should raise ValueError
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            logic.load_from_shopify_analysis(session_dir)
+
+    def test_load_from_shopify_analysis_empty_orders(self, mock_profile_manager, barcode_dir, tmp_path):
+        """Test handling of session with no orders."""
+        session_dir = tmp_path / "empty_orders_session"
+        session_dir.mkdir()
+
+        analysis_dir = session_dir / "analysis"
+        analysis_dir.mkdir()
+
+        # Analysis data with empty orders list
+        analysis_data = {
+            "analyzed_at": "2025-11-04T10:30:00",
+            "total_orders": 0,
+            "orders": []
+        }
+
+        analysis_file = analysis_dir / "analysis_data.json"
+        with open(analysis_file, 'w', encoding='utf-8') as f:
+            json.dump(analysis_data, f)
+
+        logic = PackerLogic(
+            client_id="TEST",
+            profile_manager=mock_profile_manager,
+            barcode_dir=barcode_dir
+        )
+
+        # Should return 0 orders
+        order_count, analyzed_at = logic.load_from_shopify_analysis(session_dir)
+
+        assert order_count == 0
+        assert analyzed_at == "2025-11-04T10:30:00"
+
+    def test_load_from_shopify_analysis_missing_required_columns(self, mock_profile_manager, barcode_dir, tmp_path):
+        """Test error when orders are missing required columns."""
+        session_dir = tmp_path / "invalid_columns_session"
+        session_dir.mkdir()
+
+        analysis_dir = session_dir / "analysis"
+        analysis_dir.mkdir()
+
+        # Analysis data missing 'courier' field
+        analysis_data = {
+            "analyzed_at": "2025-11-04T10:30:00",
+            "total_orders": 1,
+            "orders": [
+                {
+                    "order_number": "ORDER-001",
+                    # Missing 'courier' field
+                    "items": [
+                        {
+                            "sku": "SKU-123",
+                            "quantity": 1,
+                            "product_name": "Product A"
+                        }
+                    ]
+                }
+            ]
+        }
+
+        analysis_file = analysis_dir / "analysis_data.json"
+        with open(analysis_file, 'w', encoding='utf-8') as f:
+            json.dump(analysis_data, f)
+
+        logic = PackerLogic(
+            client_id="TEST",
+            profile_manager=mock_profile_manager,
+            barcode_dir=barcode_dir
+        )
+
+        # Should raise ValueError due to missing Courier column
+        with pytest.raises(ValueError, match="Missing required columns"):
+            logic.load_from_shopify_analysis(session_dir)
+
+    def test_load_from_shopify_analysis_extra_fields(self, mock_profile_manager, barcode_dir, tmp_path):
+        """Test handling of extra fields in Shopify data."""
+        session_dir = tmp_path / "extra_fields_session"
+        session_dir.mkdir()
+
+        analysis_dir = session_dir / "analysis"
+        analysis_dir.mkdir()
+
+        # Analysis data with extra fields
+        analysis_data = {
+            "analyzed_at": "2025-11-04T10:30:00",
+            "total_orders": 1,
+            "orders": [
+                {
+                    "order_number": "ORDER-001",
+                    "courier": "DHL",
+                    "customer_name": "John Doe",
+                    "shipping_address": "123 Main St",
+                    "items": [
+                        {
+                            "sku": "SKU-123",
+                            "quantity": 1,
+                            "product_name": "Product A"
+                        }
+                    ]
+                }
+            ]
+        }
+
+        analysis_file = analysis_dir / "analysis_data.json"
+        with open(analysis_file, 'w', encoding='utf-8') as f:
+            json.dump(analysis_data, f)
+
+        logic = PackerLogic(
+            client_id="TEST",
+            profile_manager=mock_profile_manager,
+            barcode_dir=barcode_dir
+        )
+
+        # Should successfully load and include extra fields
+        order_count, _ = logic.load_from_shopify_analysis(session_dir)
+
+        assert order_count == 1
+
+        # Check that extra fields were added to DataFrame
+        df = logic.processed_df
+        assert 'Customer_Name' in df.columns
+        assert 'Shipping_Address' in df.columns
+        assert df.loc[0, 'Customer_Name'] == 'John Doe'
+        assert df.loc[0, 'Shipping_Address'] == '123 Main St'
+
+    def test_load_from_shopify_analysis_multiple_items_per_order(self, mock_profile_manager, barcode_dir, shopify_session):
+        """Test correct flattening of orders with multiple items."""
+        session_dir, _ = shopify_session
+
+        logic = PackerLogic(
+            client_id="TEST",
+            profile_manager=mock_profile_manager,
+            barcode_dir=barcode_dir
+        )
+
+        logic.load_from_shopify_analysis(session_dir)
+
+        # ORDER-001 has 2 items, should create 2 rows
+        order_001_rows = logic.processed_df[logic.processed_df['Order_Number'] == 'ORDER-001']
+        assert len(order_001_rows) == 2
+
+        # Check both SKUs are present
+        skus = set(order_001_rows['SKU'].values)
+        assert skus == {'SKU-123', 'SKU-456'}
+
+        # Check quantities
+        sku_123_row = order_001_rows[order_001_rows['SKU'] == 'SKU-123']
+        assert sku_123_row['Quantity'].values[0] == '2'
+
+        sku_456_row = order_001_rows[order_001_rows['SKU'] == 'SKU-456']
+        assert sku_456_row['Quantity'].values[0] == '1'
+
+    def test_load_from_shopify_analysis_barcode_generation(self, mock_profile_manager, barcode_dir, shopify_session):
+        """Test that barcodes are generated for all orders."""
+        session_dir, _ = shopify_session
+
+        logic = PackerLogic(
+            client_id="TEST",
+            profile_manager=mock_profile_manager,
+            barcode_dir=barcode_dir
+        )
+
+        logic.load_from_shopify_analysis(session_dir)
+
+        # Check barcode files were created
+        barcode_path = Path(barcode_dir)
+        barcode_files = list(barcode_path.glob("*.png"))
+
+        # Should have 3 barcodes (one per order)
+        assert len(barcode_files) == 3
+
+        # Check that barcode_to_order_number mapping exists
+        assert len(logic.barcode_to_order_number) == 3
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
Implements integration between Packing Tool and Shopify Tool sessions:

## New Features:

1. **Session Selector Widget** (src/session_selector.py)
   - Dialog for selecting Shopify sessions to load
   - Displays sessions with analysis_data.json
   - Shows order count and session metadata
   - Date range filtering
   - Client-based session browsing

2. **Shopify Data Loader** (src/packer_logic.py)
   - New method: load_from_shopify_analysis()
   - Reads analysis_data.json from Shopify sessions
   - Converts Shopify order format to packing list DataFrame
   - Generates barcodes for all orders
   - Handles extra fields from Shopify analysis

3. **Main Window Integration** (src/main.py)
   - New "Load Shopify Session" button (green highlight)
   - Opens SessionSelectorDialog
   - Creates packing session from Shopify data
   - Updates UI with session info
   - Re-enables buttons after session end

## Tests:

- test_session_selector.py: Widget functionality tests
  * Client loading
  * Session scanning with Shopify data
  * Date filtering
  * Session selection

- test_shopify_integration.py: Data integration tests
  * Loading analysis_data.json
  * Order format conversion
  * Barcode generation
  * Error handling (missing files, invalid JSON)
  * Extra fields support

## Implementation Details:

- Sessions located in: Sessions/CLIENT_{ID}/*.../analysis/analysis_data.json
- Shopify sessions identified by presence of analysis_data.json
- Order data flattened from nested structure to packing list format
- Maintains compatibility with existing Excel-based workflow

## Related:

- Unified development plan Phase 1.3.2
- Integration with Shopify Tool analysis output
- Enables seamless workflow: Shopify analysis → Packing execution