### PR TITLE
Refactor PackerLogic to use unified work_dir structure

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -510,14 +510,15 @@ class MainWindow(QMainWindow):
             session_id = self.session_manager.start_session(file_path, restore_dir=restore_dir)
             logger.info(f"Session started: {session_id}")
 
-            # Get barcode directory
+            # Get barcode directory (for Excel workflow backward compatibility)
+            # This will be detected as legacy workflow in PackerLogic
             barcodes_dir = self.session_manager.get_barcodes_dir()
 
             # Create PackerLogic instance
             self.logic = PackerLogic(
                 client_id=self.current_client_id,
                 profile_manager=self.profile_manager,
-                barcode_dir=barcodes_dir
+                work_dir=barcodes_dir
             )
 
             # Connect signals
@@ -1365,25 +1366,22 @@ class MainWindow(QMainWindow):
                 # For full session, use legacy structure
                 work_dir = session_path / "packing_full_session"
 
+            # Create work directory (PackerLogic will create subdirectories)
             work_dir.mkdir(parents=True, exist_ok=True)
-
-            # Create barcodes subdirectory
-            barcodes_dir = work_dir / "barcodes"
-            barcodes_dir.mkdir(parents=True, exist_ok=True)
 
             # Store current session info
             self.current_session_path = str(session_path)
             self.current_packing_list = selected_name
             self.current_work_dir = str(work_dir)
 
-            logger.info(f"Work directory created: {work_dir}")
-            logger.info(f"Barcodes directory: {barcodes_dir}")
+            logger.info(f"Work directory: {work_dir}")
 
-            # Step 4: Create PackerLogic instance
+            # Step 4: Create PackerLogic instance with unified work_dir
+            # PackerLogic will create barcodes/ and reports/ subdirectories
             self.logic = PackerLogic(
                 client_id=self.current_client_id,
                 profile_manager=self.profile_manager,
-                barcode_dir=str(barcodes_dir)
+                work_dir=str(work_dir)
             )
 
             # Connect signals

--- a/tests/integration/test_migration.py
+++ b/tests/integration/test_migration.py
@@ -323,7 +323,7 @@ class TestMigrationWorkflow:
         packer_logic = PackerLogic(
             client_id="TEST",
             profile_manager=profile_manager,
-            barcode_dir=str(barcode_dir)
+            work_dir=str(barcode_dir)
         )
 
         # Load Shopify analysis data
@@ -359,7 +359,7 @@ class TestMigrationWorkflow:
         packer_logic = PackerLogic(
             client_id="TEST",
             profile_manager=profile_manager,
-            barcode_dir=str(barcode_dir)
+            work_dir=str(barcode_dir)
         )
 
         # Load data
@@ -398,7 +398,7 @@ class TestMigrationWorkflow:
         packer_logic = PackerLogic(
             client_id="TEST",
             profile_manager=profile_manager,
-            barcode_dir=str(barcode_dir)
+            work_dir=str(barcode_dir)
         )
 
         # Load data
@@ -471,7 +471,7 @@ class TestMigrationWorkflow:
         packer_logic = PackerLogic(
             client_id="TEST",
             profile_manager=profile_manager,
-            barcode_dir=str(barcode_dir)
+            work_dir=str(barcode_dir)
         )
 
         # Load data
@@ -573,7 +573,7 @@ class TestMigrationWorkflow:
         packer_logic = PackerLogic(
             client_id="TEST",
             profile_manager=profile_manager,
-            barcode_dir=str(barcode_dir)
+            work_dir=str(barcode_dir)
         )
 
         order_count, _ = packer_logic.load_from_shopify_analysis(session_path)
@@ -653,7 +653,7 @@ class TestMigrationEdgeCases:
             packer_logic = PackerLogic(
                 client_id="TEST",
                 profile_manager=profile_manager,
-                barcode_dir=str(barcode_dir)
+                work_dir=str(barcode_dir)
             )
 
             # Should raise error

--- a/tests/test_packer_logic.py
+++ b/tests/test_packer_logic.py
@@ -38,7 +38,7 @@ def packer_logic(mock_profile_manager, test_dir):
     return PackerLogic(
         client_id="TEST",
         profile_manager=mock_profile_manager,
-        barcode_dir=test_dir
+        work_dir=test_dir
     )
 
 

--- a/tests/test_shopify_full_workflow.py
+++ b/tests/test_shopify_full_workflow.py
@@ -186,7 +186,7 @@ class TestShopifyPackingWorkflow:
         logic = PackerLogic(
             client_id="TEST",
             profile_manager=mock_profile_manager,
-            barcode_dir=str(barcode_dir)
+            work_dir=str(barcode_dir)
         )
 
         # Load analysis data
@@ -227,7 +227,7 @@ class TestShopifyPackingWorkflow:
         logic = PackerLogic(
             client_id="TEST",
             profile_manager=mock_profile_manager,
-            barcode_dir=str(barcode_dir)
+            work_dir=str(barcode_dir)
         )
 
         # Load and process
@@ -257,7 +257,7 @@ class TestShopifyPackingWorkflow:
         logic_dhl = PackerLogic(
             client_id="TEST",
             profile_manager=mock_profile_manager,
-            barcode_dir=str(dhl_barcode_dir)
+            work_dir=str(dhl_barcode_dir)
         )
         logic_dhl.load_from_shopify_analysis(session_dir)
 
@@ -265,7 +265,7 @@ class TestShopifyPackingWorkflow:
         logic_postone = PackerLogic(
             client_id="TEST",
             profile_manager=mock_profile_manager,
-            barcode_dir=str(postone_barcode_dir)
+            work_dir=str(postone_barcode_dir)
         )
         logic_postone.load_from_shopify_analysis(session_dir)
 
@@ -294,7 +294,7 @@ class TestShopifyPackingWorkflow:
         logic = PackerLogic(
             client_id="TEST",
             profile_manager=mock_profile_manager,
-            barcode_dir=str(barcode_dir)
+            work_dir=str(barcode_dir)
         )
 
         # Load data

--- a/tests/test_shopify_integration.py
+++ b/tests/test_shopify_integration.py
@@ -112,7 +112,7 @@ class TestShopifyIntegration:
         logic = PackerLogic(
             client_id="TEST",
             profile_manager=mock_profile_manager,
-            barcode_dir=barcode_dir
+            work_dir=barcode_dir
         )
 
         # Load from Shopify analysis
@@ -157,7 +157,7 @@ class TestShopifyIntegration:
         logic = PackerLogic(
             client_id="TEST",
             profile_manager=mock_profile_manager,
-            barcode_dir=barcode_dir
+            work_dir=barcode_dir
         )
 
         # Should raise ValueError
@@ -180,7 +180,7 @@ class TestShopifyIntegration:
         logic = PackerLogic(
             client_id="TEST",
             profile_manager=mock_profile_manager,
-            barcode_dir=barcode_dir
+            work_dir=barcode_dir
         )
 
         # Should raise ValueError
@@ -209,7 +209,7 @@ class TestShopifyIntegration:
         logic = PackerLogic(
             client_id="TEST",
             profile_manager=mock_profile_manager,
-            barcode_dir=barcode_dir
+            work_dir=barcode_dir
         )
 
         # Should return 0 orders
@@ -252,7 +252,7 @@ class TestShopifyIntegration:
         logic = PackerLogic(
             client_id="TEST",
             profile_manager=mock_profile_manager,
-            barcode_dir=barcode_dir
+            work_dir=barcode_dir
         )
 
         # Should raise ValueError due to missing Courier column
@@ -295,7 +295,7 @@ class TestShopifyIntegration:
         logic = PackerLogic(
             client_id="TEST",
             profile_manager=mock_profile_manager,
-            barcode_dir=barcode_dir
+            work_dir=barcode_dir
         )
 
         # Should successfully load and include extra fields
@@ -317,7 +317,7 @@ class TestShopifyIntegration:
         logic = PackerLogic(
             client_id="TEST",
             profile_manager=mock_profile_manager,
-            barcode_dir=barcode_dir
+            work_dir=barcode_dir
         )
 
         logic.load_from_shopify_analysis(session_dir)
@@ -344,7 +344,7 @@ class TestShopifyIntegration:
         logic = PackerLogic(
             client_id="TEST",
             profile_manager=mock_profile_manager,
-            barcode_dir=barcode_dir
+            work_dir=barcode_dir
         )
 
         logic.load_from_shopify_analysis(session_dir)


### PR DESCRIPTION
Changed PackerLogic to accept work_dir instead of barcode_dir parameter, enabling full integration with unified session structure.

Changes:
- PackerLogic.__init__() now accepts work_dir parameter
- Automatically creates barcodes/ and reports/ subdirectories
- State files (packing_state.json, session_summary.json) stored in work_dir root
- Backward compatible with Excel workflow (detects legacy barcode_dir pattern)
- Updated all PackerLogic instantiations in main.py and tests

Directory structure:
Unified workflow:
  work_dir/ (e.g., Sessions/CLIENT_M/2025-11-10_1/packing/DHL_Orders/) ├── packing_state.json ├── session_summary.json ├── barcodes/
  │   └── ORDER-001.png
  └── reports/
      └── packing_report.xlsx

Excel workflow (backward compatible):
  work_dir/ (e.g., Sessions/CLIENT_M/2025-11-10_1/barcodes/) ├── packing_state.json ├── session_summary.json └── ORDER-001.png

Files modified:
- src/packer_logic.py: Refactored __init__, _get_state_file_path, _get_summary_file_path
- src/main.py: Updated PackerLogic instantiations for both Excel and unified workflows
- tests/*: Updated all test files to use work_dir parameter