### PR TITLE
Fix barcode path assertions in test

### DIFF
--- a/tests/test_packer_logic.py
+++ b/tests/test_packer_logic.py
@@ -97,8 +97,12 @@ def test_successful_processing_and_barcode_generation(packer_logic, dummy_file_p
     num_orders = packer_logic.process_data_and_generate_barcodes()
     assert num_orders == 2
 
-    assert os.path.exists(os.path.join(test_dir, '1001.png'))
-    assert os.path.exists(os.path.join(test_dir, '1002.png'))
+    # Check barcode files exist in test_dir/barcodes/ subdirectory
+    barcode_dir = os.path.join(test_dir, 'barcodes')
+    assert os.path.exists(os.path.join(barcode_dir, '1001.png')), \
+        f"Expected barcode file not found: {os.path.join(barcode_dir, '1001.png')}"
+    assert os.path.exists(os.path.join(barcode_dir, '1002.png')), \
+        f"Expected barcode file not found: {os.path.join(barcode_dir, '1002.png')}"
 
     assert '1001' in packer_logic.orders_data
     assert len(packer_logic.orders_data['1001']['items']) == 2


### PR DESCRIPTION
…factoring

After Phase 1.2 PackerLogic work_dir refactoring, barcodes are now stored in work_dir/barcodes/ subdirectory instead of work_dir/ root.

Updated test assertions to check for barcode files in the correct location:
- Changed from test_dir/1001.png to test_dir/barcodes/1001.png
- Changed from test_dir/1002.png to test_dir/barcodes/1002.png
- Added informative error messages for assertion failures

All 19 tests in test_packer_logic.py now pass.