### PR TITLE
Fix double client selection in session dialog

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1327,6 +1327,9 @@ class MainWindow(QMainWindow):
         2. Automatically scan packing_lists/ folder
         3. User can select specific packing list or load entire session
         4. Create work directory: packing/{list_name}/ for selected lists
+
+        If a client is already selected in the main menu, it will be
+        pre-selected in the dialog (no need to select twice).
         """
         logger.info("Opening Shopify session selector")
 
@@ -1353,7 +1356,12 @@ class MainWindow(QMainWindow):
             return
 
         # Step 1: Use SessionSelectorDialog to select session and packing list
-        selector_dialog = SessionSelectorDialog(self.profile_manager, self)
+        # Pass pre-selected client from main menu to avoid double selection
+        selector_dialog = SessionSelectorDialog(
+            profile_manager=self.profile_manager,
+            pre_selected_client=self.current_client_id,
+            parent=self
+        )
 
         if not selector_dialog.exec():
             logger.info("Shopify session selection cancelled")


### PR DESCRIPTION
## Problem
Users had to select client twice:
1. In main menu client selector
2. Again in SessionSelectorDialog when opening Shopify session

This created unnecessary friction and potential confusion.

## Solution
- SessionSelectorDialog now accepts optional `pre_selected_client` parameter
- When pre_selected_client is provided:
  * Client ComboBox is hidden
  * Static label displays selected client
  * Sessions are automatically filtered to that client
  * Window title shows pre-selected client
- open_shopify_session() now passes self.current_client_id to dialog
- Fully backward compatible (works without pre-selection)

## Changes
- src/session_selector.py:
  * Add pre_selected_client parameter to __init__()
  * Implement _apply_pre_selection() method
  * Add _refresh_sessions_for_client() helper method
  * Refactor _refresh_sessions() to use unified logic

- src/main.py:
  * Update open_shopify_session() to pass current_client_id
  * Add documentation about pre-selection behavior

## User Experience Improvement
Before: Client selection → Open dialog → Select client AGAIN → Select session After:  Client selection → Open dialog → Select session (client already set)

Reduces steps from 4 to 3, eliminates confusion about client mismatch.

## Testing
- ✅ Syntax validation passed (py_compile)
- ✅ Backward compatible (works with pre_selected_client=None)
- Ready for manual testing with actual client data

Related to: P2 UX improvement task