### PR TITLE
Fix: PyInstaller build - Add shared module support

### DIFF
--- a/main.spec
+++ b/main.spec
@@ -3,11 +3,12 @@
 
 a = Analysis(
     ['src/main.py'],
-    pathex=['src'],
+    pathex=['src', '.'],  # Added '.' for project root (to find 'shared' module)
     binaries=[],
     datas=[
         ('src/styles.qss', 'src'),
         ('config.ini.example', '.'),
+        ('shared', 'shared'),  # Include shared module directory
     ],
     hiddenimports=[
         'exceptions',
@@ -17,6 +18,8 @@ a = Analysis(
         'logger',
         'profile_manager',
         'session_manager',
+        'shared',
+        'shared.stats_manager',
     ],
     hookspath=[],
     hooksconfig={},


### PR DESCRIPTION
## Problem
PyInstaller .exe build failed with:
  ModuleNotFoundError: No module named 'shared'

## Root Cause
- main.py imports 'from shared.stats_manager import StatsManager'
- PyInstaller spec file missing 'shared' module configuration
- Project root (containing 'shared/') not in pathex
- 'shared' module not included in hiddenimports or datas

## Solution

### 1. Added project root to pathex
```python
pathex=['src', '.']  # Added '.' for project root
```

### 2. Included shared directory in datas
```python
datas=[
    ...,
    ('shared', 'shared'),  # Include shared module directory
]
```

### 3. Added hidden imports
```python
hiddenimports=[
    ...,
    'shared',
    'shared.stats_manager',
]
```

## Changes
- **main.spec**:
  - pathex: Added '.' for project root access
  - datas: Added ('shared', 'shared') to bundle module
  - hiddenimports: Added 'shared' and 'shared.stats_manager'

## Testing
After rebuild:
```bash
pyinstaller main.spec
dist/Packers-Assistant.exe  # Should now work without ModuleNotFoundError
```

## Impact
- ✅ Fixes .exe build for production deployment
- ✅ No impact on source code
- ✅ Compatible with existing development workflow
- ✅ Required for v1.2.0 production release

## Related
- Issue: PyInstaller can't find 'shared' module
- Affects: Production .exe builds only
- Status: FIXED