### PR TITLE
fix: 8 small UI fixes — hover, colors, menu, crashes, theme

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -734,7 +734,8 @@ class MainWindow(QMainWindow):
                 card_layout = QVBoxLayout(card)
                 card_layout.setContentsMargins(12, 8, 12, 8)
                 card_layout.setSpacing(2)
-                card.setStyleSheet("QWidget { border: 1px solid #2a2a2a; border-radius: 4px; }")
+                card.setObjectName("courier_card")
+                card.setStyleSheet("#courier_card { border: 1px solid #2a2a2a; border-radius: 4px; }")
                 value_lbl = QLabel(str(orders))
                 value_lbl.setFont(card_bold_font)
                 value_lbl.setAlignment(Qt.AlignCenter)
@@ -1828,6 +1829,7 @@ class MainWindow(QMainWindow):
         """Switches the view back to the main session widget (tabbed interface)."""
         if self.logic:
             self.logic.clear_current_order()
+        if self.packer_mode_widget:
             self.packer_mode_widget.clear_screen()
         self.stacked_widget.setCurrentWidget(self.session_widget)
 

--- a/src/main.py
+++ b/src/main.py
@@ -299,22 +299,12 @@ class MainWindow(QMainWindow):
         # File menu
         file_menu = menubar.addMenu("&File")
 
-        import_action = QAction("Import Packing List...", self)
-        import_action.triggered.connect(lambda: self.start_session())
-        file_menu.addAction(import_action)
-
-        file_menu.addSeparator()
-
         exit_action = QAction("Exit", self)
         exit_action.triggered.connect(self.close)
         file_menu.addAction(exit_action)
 
         # Session menu
         session_menu = menubar.addMenu("&Session")
-
-        new_session_action = QAction("Start New Session", self)
-        new_session_action.triggered.connect(lambda: self.start_session())
-        session_menu.addAction(new_session_action)
 
         shopify_session_action = QAction("Open Shopify Session...", self)
         shopify_session_action.setShortcut(QKeySequence("Ctrl+O"))
@@ -667,10 +657,12 @@ class MainWindow(QMainWindow):
 
         # --- By Courier ---
         courier_group = QGroupBox("By Courier")
-        courier_layout = QVBoxLayout()
+        courier_layout = QHBoxLayout()
         self.courier_stats_widget = QWidget()
-        self.courier_stats_layout = QVBoxLayout(self.courier_stats_widget)
+        self.courier_stats_layout = QHBoxLayout(self.courier_stats_widget)
+        self.courier_stats_layout.setSpacing(16)
         courier_layout.addWidget(self.courier_stats_widget)
+        courier_layout.addStretch()
         courier_group.setLayout(courier_layout)
         scroll_layout.addWidget(courier_group)
 
@@ -729,15 +721,35 @@ class MainWindow(QMainWindow):
             }).reset_index()
 
             # OPTIMIZED: replaced iterrows() with itertuples() for 5-10x speedup
+            card_bold_font = QFont()
+            card_bold_font.setPointSize(18)
+            card_bold_font.setBold(True)
+            card_label_font = QFont()
+            card_label_font.setPointSize(9)
             for row_tuple in courier_stats.itertuples(index=False):
                 courier = row_tuple.Courier
                 orders = row_tuple.Order_Number
                 items = int(row_tuple.Quantity) if pd.notna(row_tuple.Quantity) else 0
-                label = QLabel(f"• {courier}: {orders} orders ({items} items)")
-                font = QFont()
-                font.setPointSize(11)
-                label.setFont(font)
-                self.courier_stats_layout.addWidget(label)
+                card = QWidget()
+                card_layout = QVBoxLayout(card)
+                card_layout.setContentsMargins(12, 8, 12, 8)
+                card_layout.setSpacing(2)
+                card.setStyleSheet("QWidget { border: 1px solid #2a2a2a; border-radius: 4px; }")
+                value_lbl = QLabel(str(orders))
+                value_lbl.setFont(card_bold_font)
+                value_lbl.setAlignment(Qt.AlignCenter)
+                courier_lbl = QLabel(courier)
+                courier_lbl.setFont(card_label_font)
+                courier_lbl.setAlignment(Qt.AlignCenter)
+                courier_lbl.setStyleSheet("color: #888888; border: none;")
+                items_lbl = QLabel(f"{items} items")
+                items_lbl.setFont(card_label_font)
+                items_lbl.setAlignment(Qt.AlignCenter)
+                items_lbl.setStyleSheet("color: #666666; border: none;")
+                card_layout.addWidget(value_lbl)
+                card_layout.addWidget(courier_lbl)
+                card_layout.addWidget(items_lbl)
+                self.courier_stats_layout.addWidget(card)
 
         # SKU Summary
         sku_summary = df.groupby(['SKU', 'Product_Name']).agg({
@@ -828,6 +840,8 @@ class MainWindow(QMainWindow):
                 worker = self.worker_manager.get_worker(self.current_worker_id)
                 if worker:
                     self.current_worker_name = worker.name
+                    if hasattr(self, 'sb_worker_label'):
+                        self.sb_worker_label.setText(f"Worker: {self.current_worker_name}")
                     logger.info(f"Logged in as: {self.current_worker_name} ({self.current_worker_id})")
                     return True
 
@@ -1812,9 +1826,9 @@ class MainWindow(QMainWindow):
 
     def switch_to_session_view(self):
         """Switches the view back to the main session widget (tabbed interface)."""
-        self.logic.clear_current_order()
-        self.packer_mode_widget.clear_screen()
-        # Phase 1.3: Return to tabbed widget (Session tab will be active)
+        if self.logic:
+            self.logic.clear_current_order()
+            self.packer_mode_widget.clear_screen()
         self.stacked_widget.setCurrentWidget(self.session_widget)
 
     def open_print_dialog(self):

--- a/src/session_browser/active_sessions_tab.py
+++ b/src/session_browser/active_sessions_tab.py
@@ -415,6 +415,7 @@ class ActiveSessionsTab(QWidget):
         """Fill table with session data."""
         self.table.setRowCount(len(self.sessions))
 
+        is_dark = QSettings("PackingTool", "Theme").value("current_theme", "dark") == "dark"
         for row, session in enumerate(self.sessions):
             # Session ID
             self.table.setItem(row, 0, QTableWidgetItem(session['session_id']))
@@ -427,7 +428,6 @@ class ActiveSessionsTab(QWidget):
 
             # Status (with theme-aware color)
             status_item = QTableWidgetItem(session['status'])
-            is_dark = QSettings("PackingTool", "Theme").value("current_theme", "dark") == "dark"
             if session['status'] == 'Active':
                 status_item.setBackground(QColor(26, 61, 26) if is_dark else QColor(200, 240, 200))
                 status_item.setForeground(QColor(127, 212, 127) if is_dark else QColor(20, 100, 20))

--- a/src/session_browser/active_sessions_tab.py
+++ b/src/session_browser/active_sessions_tab.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import (
     QTableWidget, QTableWidgetItem, QComboBox, QHeaderView,
     QMessageBox, QLabel
 )
-from PySide6.QtCore import Signal, QTimer
+from PySide6.QtCore import Signal, QTimer, QSettings
 from PySide6.QtGui import QColor
 
 from pathlib import Path
@@ -425,14 +425,18 @@ class ActiveSessionsTab(QWidget):
             # Packing List
             self.table.setItem(row, 2, QTableWidgetItem(session['packing_list_name']))
 
-            # Status (with color)
+            # Status (with theme-aware color)
             status_item = QTableWidgetItem(session['status'])
+            is_dark = QSettings("PackingTool", "Theme").value("current_theme", "dark") == "dark"
             if session['status'] == 'Active':
-                status_item.setBackground(QColor(200, 255, 200))  # Light green
+                status_item.setBackground(QColor(26, 61, 26) if is_dark else QColor(200, 240, 200))
+                status_item.setForeground(QColor(127, 212, 127) if is_dark else QColor(20, 100, 20))
             elif session['status'] == 'Stale':
-                status_item.setBackground(QColor(255, 200, 200))  # Light red
+                status_item.setBackground(QColor(61, 26, 26) if is_dark else QColor(240, 200, 200))
+                status_item.setForeground(QColor(212, 127, 127) if is_dark else QColor(160, 20, 20))
             else:  # Paused
-                status_item.setBackground(QColor(255, 255, 200))  # Light yellow
+                status_item.setBackground(QColor(61, 61, 26) if is_dark else QColor(240, 240, 190))
+                status_item.setForeground(QColor(212, 212, 127) if is_dark else QColor(100, 100, 20))
             self.table.setItem(row, 3, status_item)
 
             # Worker

--- a/src/session_browser/metrics_tab.py
+++ b/src/session_browser/metrics_tab.py
@@ -40,11 +40,11 @@ class MetricsTab(QWidget):
 
         if not metrics:
             no_data_label = QLabel(
-                "⚠️ Metrics not available\n\n"
-                "This session was created before Phase 2b or has no timing data."
+                "ℹ️ Metrics not available\n\n"
+                "Timing metrics are not available for this session."
             )
             no_data_label.setObjectName("no_metrics_label")
-            no_data_label.setStyleSheet("color: #b06020; font-weight: bold;")
+            no_data_label.setStyleSheet("color: #888888; font-weight: bold;")
             no_data_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             layout.addWidget(no_data_label)
             layout.addStretch()

--- a/src/session_browser/orders_tab.py
+++ b/src/session_browser/orders_tab.py
@@ -115,8 +115,8 @@ class OrdersTab(QWidget):
 
         # Update info label
         if not self.all_orders:
-            self.info_label.setText("⚠️ No order timing data available (Session created before Phase 2b)")
-            self.info_label.setStyleSheet("color: orange; font-weight: bold;")
+            self.info_label.setText("ℹ️ No order data available for this session.")
+            self.info_label.setStyleSheet("color: #888888; font-weight: bold;")
             return
         else:
             self.info_label.setText(f"Showing {len(self.filtered_orders)} of {len(self.all_orders)} orders")

--- a/src/session_selector.py
+++ b/src/session_selector.py
@@ -20,8 +20,9 @@ import json
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QComboBox,
     QListWidget, QListWidgetItem, QPushButton, QDateEdit,
-    QCheckBox, QMessageBox, QGroupBox
+    QCheckBox, QMessageBox, QGroupBox, QApplication
 )
+from PySide6.QtGui import QPalette
 from PySide6.QtCore import Qt, QDate
 
 from logger import get_logger
@@ -559,7 +560,7 @@ class SessionSelectorDialog(QDialog):
 
                     list_item.setText(display_text)
                     list_item.setData(Qt.UserRole, pl)
-                    list_item.setForeground(Qt.darkBlue)
+                    list_item.setForeground(QApplication.palette().color(QPalette.Text))
 
                     self.packing_lists_widget.addItem(list_item)
 

--- a/src/styles_light.qss
+++ b/src/styles_light.qss
@@ -9,6 +9,10 @@ QWidget {
     font-size: 11pt;
 }
 
+QLabel {
+    background-color: transparent;
+}
+
 QWidget:disabled {
     color: #aaaaaa;
 }

--- a/src/worker_selection_dialog.py
+++ b/src/worker_selection_dialog.py
@@ -41,8 +41,12 @@ class WorkerCard(QFrame):
                 padding: 12px;
             }
             WorkerCard:hover {
-                background-color: #0f1a2a;
+                background-color: #1a3a5c;
                 border: 1px solid #5a9fd4;
+            }
+            WorkerCard:hover QLabel {
+                color: #ffffff;
+                background-color: transparent;
             }
         """)
 

--- a/tests/test_gui_navigation.py
+++ b/tests/test_gui_navigation.py
@@ -468,11 +468,11 @@ class TestDialogsAndStatusBar(unittest.TestCase):
             dialog.close()
 
     def test_metrics_tab_no_data_label(self):
-        """MetricsTab with no metrics should show the no_metrics_label with #b06020."""
+        """MetricsTab with no metrics should show the no_metrics_label."""
         tab = MetricsTab(details={})
         label = tab.findChild(QLabel, "no_metrics_label")
         self.assertIsNotNone(label)
-        self.assertIn("#b06020", label.styleSheet())
+        self.assertIn("#888888", label.styleSheet())
 
     def test_metrics_tab_scroll_area(self):
         """MetricsTab should always wrap content in a widgetResizable QScrollArea."""


### PR DESCRIPTION
- Worker card hover now shows full blue highlight with white text on child QLabels
- Packing list text color is now palette-aware (white/dark per theme)
- Removed legacy 'Import Packing List' and 'Start New Session' menu items
- Back to Menu no longer crashes when session ended inside Packer Mode
- Worker change via Settings now updates status bar label immediately
- Session Browser status colors are now muted and theme-aware (dark/light)
- 'Phase 2b' messaging replaced with neutral 'data not available' wording
- By Courier section now renders as horizontal stat cards matching Session Totals
- Light theme: QLabel background set to transparent to fix gray patches under text

## Summary by Sourcery

Apply multiple small UI and stability improvements across the main window, session browser, metrics, and worker selection flows.

New Features:
- Render By Courier metrics as horizontal stat cards consistent with other statistics sections.

Bug Fixes:
- Prevent crashes when returning from Packer Mode after a session has ended by safely clearing the current order state.
- Ensure the currently selected worker name in settings is immediately reflected in the status bar label.

Enhancements:
- Remove legacy session-related menu items from the File and Session menus to simplify navigation.
- Make session status colors in the Session Browser theme-aware and visually softer in both dark and light modes.
- Update no-data messages in session metrics and orders views to use neutral, user-friendly wording and styling.
- Improve worker selection hover styling so the entire card highlights and child labels render with high-contrast text.
- Make packing list text color use the application palette so it adapts correctly to light and dark themes.