### PR TITLE
feat: local SQLite cache, metrics fix, excess item detection

### DIFF
--- a/src/local_db.py
+++ b/src/local_db.py
@@ -1,0 +1,221 @@
+"""
+Local SQLite cache for session data.
+
+Stores session metadata locally per-PC to avoid repeated slow file-server scans.
+The file server remains the source of truth — this is a read-through cache only.
+
+DB location: %%APPDATA%%\\PackingTool\\local_cache.db  (Windows)
+             ~/.local/share/PackingTool/local_cache.db  (Linux/Mac fallback)
+"""
+
+import sqlite3
+import time
+import os
+from pathlib import Path
+from typing import Optional
+
+
+# TTL constants (seconds) by session status
+CACHE_TTL_COMPLETED = 3600   # 1 hour — completed sessions are immutable
+CACHE_TTL_AVAILABLE = 300    # 5 minutes — rarely changes
+CACHE_TTL_IN_PROGRESS = 30   # 30 seconds — must stay fresh (heartbeat is 60s)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS session_cache (
+    session_path        TEXT PRIMARY KEY,
+    client_id           TEXT NOT NULL,
+    session_id          TEXT,
+    packing_list_name   TEXT,
+    status              TEXT NOT NULL,
+    pc_name             TEXT,
+    worker_name         TEXT,
+    start_time          TEXT,
+    end_time            TEXT,
+    duration_seconds    INTEGER,
+    total_orders        INTEGER,
+    completed_orders    INTEGER,
+    total_items_packed  INTEGER,
+    last_synced         REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_client_status ON session_cache (client_id, status);
+CREATE INDEX IF NOT EXISTS idx_last_synced   ON session_cache (last_synced);
+"""
+
+
+def get_db_path() -> Path:
+    if os.name == "nt":
+        base = Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming"))
+    else:
+        base = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    db_dir = base / "PackingTool"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    return db_dir / "local_cache.db"
+
+
+class LocalDB:
+    """Thread-safe SQLite wrapper for local session cache."""
+
+    def __init__(self, db_path: Optional[Path] = None):
+        self._path = str(db_path or get_db_path())
+        self._init_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._path, timeout=5)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(_SCHEMA)
+
+    # ------------------------------------------------------------------
+    # Write operations
+    # ------------------------------------------------------------------
+
+    def upsert_session(self, session_data: dict) -> None:
+        """Insert or replace a session row. Automatically sets last_synced."""
+        row = {
+            "session_path":      session_data.get("session_path", ""),
+            "client_id":         session_data.get("client_id", ""),
+            "session_id":        session_data.get("session_id"),
+            "packing_list_name": session_data.get("packing_list_name"),
+            "status":            session_data.get("status", "available"),
+            "pc_name":           session_data.get("pc_name"),
+            "worker_name":       session_data.get("worker_name"),
+            "start_time":        session_data.get("start_time"),
+            "end_time":          session_data.get("end_time"),
+            "duration_seconds":  session_data.get("duration_seconds"),
+            "total_orders":      session_data.get("total_orders"),
+            "completed_orders":  session_data.get("completed_orders"),
+            "total_items_packed":session_data.get("total_items_packed"),
+            "last_synced":       time.time(),
+        }
+        sql = """
+            INSERT OR REPLACE INTO session_cache
+                (session_path, client_id, session_id, packing_list_name, status,
+                 pc_name, worker_name, start_time, end_time, duration_seconds,
+                 total_orders, completed_orders, total_items_packed, last_synced)
+            VALUES
+                (:session_path, :client_id, :session_id, :packing_list_name, :status,
+                 :pc_name, :worker_name, :start_time, :end_time, :duration_seconds,
+                 :total_orders, :completed_orders, :total_items_packed, :last_synced)
+        """
+        with self._connect() as conn:
+            conn.execute(sql, row)
+
+    def upsert_sessions(self, sessions: list[dict]) -> None:
+        """Bulk upsert — more efficient than calling upsert_session() in a loop."""
+        now = time.time()
+        rows = []
+        for s in sessions:
+            rows.append((
+                s.get("session_path", ""),
+                s.get("client_id", ""),
+                s.get("session_id"),
+                s.get("packing_list_name"),
+                s.get("status", "available"),
+                s.get("pc_name"),
+                s.get("worker_name"),
+                s.get("start_time"),
+                s.get("end_time"),
+                s.get("duration_seconds"),
+                s.get("total_orders"),
+                s.get("completed_orders"),
+                s.get("total_items_packed"),
+                now,
+            ))
+        sql = """
+            INSERT OR REPLACE INTO session_cache
+                (session_path, client_id, session_id, packing_list_name, status,
+                 pc_name, worker_name, start_time, end_time, duration_seconds,
+                 total_orders, completed_orders, total_items_packed, last_synced)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        """
+        with self._connect() as conn:
+            conn.executemany(sql, rows)
+
+    def delete_session(self, session_path: str) -> None:
+        with self._connect() as conn:
+            conn.execute("DELETE FROM session_cache WHERE session_path = ?", (session_path,))
+
+    def purge_stale(self, max_age_seconds: float) -> int:
+        """Remove rows older than max_age_seconds. Returns number of rows deleted."""
+        cutoff = time.time() - max_age_seconds
+        with self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM session_cache WHERE last_synced < ?", (cutoff,)
+            )
+            return cur.rowcount
+
+    # ------------------------------------------------------------------
+    # Read operations
+    # ------------------------------------------------------------------
+
+    def get_sessions_by_status(self, client_id: str, status: str) -> list[dict]:
+        sql = """
+            SELECT * FROM session_cache
+            WHERE client_id = ? AND status = ?
+            ORDER BY start_time DESC
+        """
+        with self._connect() as conn:
+            rows = conn.execute(sql, (client_id, status)).fetchall()
+        return [dict(r) for r in rows]
+
+    def get_all_sessions(self, client_id: str) -> list[dict]:
+        sql = "SELECT * FROM session_cache WHERE client_id = ? ORDER BY start_time DESC"
+        with self._connect() as conn:
+            rows = conn.execute(sql, (client_id,)).fetchall()
+        return [dict(r) for r in rows]
+
+    def get_session(self, session_path: str) -> Optional[dict]:
+        sql = "SELECT * FROM session_cache WHERE session_path = ?"
+        with self._connect() as conn:
+            row = conn.execute(sql, (session_path,)).fetchone()
+        return dict(row) if row else None
+
+    def is_stale(self, session_path: str, status: str) -> bool:
+        """Return True if session is missing from cache or its TTL has expired."""
+        ttl = {
+            "completed":   CACHE_TTL_COMPLETED,
+            "available":   CACHE_TTL_AVAILABLE,
+            "in_progress": CACHE_TTL_IN_PROGRESS,
+        }.get(status, CACHE_TTL_AVAILABLE)
+
+        row = self.get_session(session_path)
+        if row is None:
+            return True
+        age = time.time() - row["last_synced"]
+        return age > ttl
+
+    def get_stale_paths(self, client_id: str, status: str) -> list[str]:
+        """Return list of session_paths for this client+status that are stale."""
+        ttl = {
+            "completed":   CACHE_TTL_COMPLETED,
+            "available":   CACHE_TTL_AVAILABLE,
+            "in_progress": CACHE_TTL_IN_PROGRESS,
+        }.get(status, CACHE_TTL_AVAILABLE)
+        cutoff = time.time() - ttl
+        sql = """
+            SELECT session_path FROM session_cache
+            WHERE client_id = ? AND status = ? AND last_synced < ?
+        """
+        with self._connect() as conn:
+            rows = conn.execute(sql, (client_id, status, cutoff)).fetchall()
+        return [r["session_path"] for r in rows]
+
+    def count_by_status(self, client_id: str) -> dict:
+        """Return dict of {status: count} for a client."""
+        sql = """
+            SELECT status, COUNT(*) as cnt
+            FROM session_cache
+            WHERE client_id = ?
+            GROUP BY status
+        """
+        with self._connect() as conn:
+            rows = conn.execute(sql, (client_id,)).fetchall()
+        return {r["status"]: r["cnt"] for r in rows}
+
+    def clear_all(self) -> None:
+        """Remove all rows from the cache (equivalent to old clear_cache())."""
+        with self._connect() as conn:
+            conn.execute("DELETE FROM session_cache")

--- a/src/main.py
+++ b/src/main.py
@@ -1950,12 +1950,12 @@ class MainWindow(QMainWindow):
         msg.exec()
 
         if msg.clickedButton() == confirm_btn:
+            # confirm_order_complete_with_excess() resets current_order_number internally
             self.logic.confirm_order_complete_with_excess()
             self.packer_mode_widget.show_notification(f"ORDER {order_num} COMPLETE!", "#43a047")
             self.flash_border("green")
             self.update_order_status(order_num, "Completed")
             self.packer_mode_widget.scanner_input.setEnabled(False)
-            self.logic.clear_current_order()
             QTimer.singleShot(3000, self.packer_mode_widget.clear_screen)
         else:
             # Cancel the last excess entry

--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -124,20 +124,23 @@ class PackerLogic(QObject):
         # Load SKU mapping from ProfileManager
         self.sku_map = self._load_sku_mapping()
 
-        # Load session state if exists
-        self._load_session_state()
-
-        # Phase 2b: Order-level timing tracking
+        # Phase 2b: Order-level timing tracking — initialised BEFORE _load_session_state()
+        # so that _load_session_state() can overwrite them when resuming an existing session.
         self.current_order_start_time = None  # ISO timestamp when order scanning started
         self.current_order_items_scanned = []  # List of items with scan timestamps
-        self.completed_orders_metadata = []  # List of completed orders with timing data
+        self.completed_orders_metadata = []    # List of completed orders with timing data
+
+        # Excess scan tracking — reset per order in start_order_packing()
+        self.current_order_excess_scans: list = []
+
+        # Load session state if exists (may overwrite timing variables above)
+        self._load_session_state()
 
         logger.info(f"PackerLogic initialized for client {client_id}")
         logger.debug(f"Work directory: {self.work_dir}")
         logger.debug(f"Barcode directory: {self.barcode_dir}")
         logger.debug(f"Reports directory: {self.reports_dir}")
         logger.debug(f"Loaded {len(self.sku_map)} SKU mappings")
-        logger.debug("Phase 2b timing variables initialized")
 
     def _load_sku_mapping(self) -> Dict[str, str]:
         """
@@ -804,6 +807,7 @@ class PackerLogic(QObject):
         from shared.metadata_utils import get_current_timestamp
         self.current_order_start_time = get_current_timestamp()
         self.current_order_items_scanned = []
+        self.current_order_excess_scans = []  # Reset excess tracking for each new order
 
         logger.info(f"Order {original_order_number} started at {self.current_order_start_time}")
 
@@ -841,7 +845,8 @@ class PackerLogic(QObject):
                   * "SKU_OK" - Item packed successfully, order still in progress
                   * "ORDER_COMPLETE" - Item packed and order is now complete
                   * "SKU_NOT_FOUND" - Scanned SKU is not in this order
-                  * "SKU_EXTRA" - All items with this SKU are already packed
+                  * "SKU_EXTRA" - All items with this SKU are already packed (no excess yet recorded)
+                  * "SKU_EXCESS_TRACKED" - Excess scan recorded; all items complete, needs confirmation
                   * "NO_ACTIVE_ORDER" - No order currently selected
         """
         # Safety check: ensure an order is actually loaded
@@ -989,13 +994,65 @@ class PackerLogic(QObject):
         is_sku_in_order = any(s['normalized_sku'] == normalized_final_sku for s in self.current_order_state)
 
         if is_sku_in_order:
-            # SKU is in order, but all required quantity already packed
-            # Example: Order needs 2x "SKU-CREAM-01", but user scanned it 3 times
-            return None, "SKU_EXTRA"  # All items with this SKU are already packed
+            # SKU is in order but all required quantity already packed — record excess scan
+            from shared.metadata_utils import get_current_timestamp
+            excess_record = {
+                "sku": normalized_final_sku,
+                "scanned_at": get_current_timestamp(),
+            }
+            self.current_order_excess_scans.append(excess_record)
+            logger.warning(
+                f"Excess scan for {normalized_final_sku} in order {self.current_order_number} "
+                f"({len(self.current_order_excess_scans)} excess total)"
+            )
+            return None, "SKU_EXCESS_TRACKED"
         else:
             # SKU is not in this order at all
             # Example: User scanned wrong product, or product from different order
             return None, "SKU_NOT_FOUND"
+
+    # ------------------------------------------------------------------
+    # Excess scan management
+    # ------------------------------------------------------------------
+
+    def get_current_order_excess(self) -> list:
+        """Return list of excess scan records for the current order."""
+        return list(self.current_order_excess_scans)
+
+    def confirm_order_complete_with_excess(self):
+        """
+        Complete the current order despite excess scans (worker confirmed).
+        Clears excess records and calls the normal order-completion path.
+        """
+        if not self.current_order_number:
+            return
+
+        self.current_order_excess_scans = []
+        self._complete_current_order()
+        del self.session_packing_state['in_progress'][self.current_order_number]
+        if self.current_order_number not in self.session_packing_state['completed_orders']:
+            self.session_packing_state['completed_orders'].append(self.current_order_number)
+        self._save_session_state()
+        logger.info(f"Order {self.current_order_number} completed with excess confirmation")
+
+    def cancel_excess_scan(self, sku: str | None = None):
+        """
+        Remove the last excess scan record (worker chose to ignore/cancel it).
+
+        Args:
+            sku: If provided, removes the last excess entry for that specific SKU.
+                 If None, removes the most recent excess entry regardless of SKU.
+        """
+        if not self.current_order_excess_scans:
+            return
+        if sku is None:
+            self.current_order_excess_scans.pop()
+        else:
+            normalized = self._normalize_sku(sku)
+            for i in range(len(self.current_order_excess_scans) - 1, -1, -1):
+                if self.current_order_excess_scans[i].get("sku") == normalized:
+                    self.current_order_excess_scans.pop(i)
+                    break
 
     def clear_current_order(self):
         """Clears the currently active order from memory."""
@@ -1593,6 +1650,72 @@ class PackerLogic(QObject):
         except Exception as e:
             logger.error(f"Failed to save session summary: {e}", exc_info=True)
             raise IOError(f"Failed to save session summary: {e}")
+
+    def save_state(self):
+        """Public alias for _save_session_state() — used by closeEvent."""
+        self._save_session_state()
+
+    def is_session_active(self) -> bool:
+        """Return True if a packing session is currently loaded and has data."""
+        return bool(
+            self.orders_data
+            or self.session_packing_state.get('in_progress')
+            or self.session_packing_state.get('completed_orders')
+        )
+
+    def save_partial_summary(
+        self,
+        worker_id: str = None,
+        worker_name: str = None,
+        session_type: str = "shopify"
+    ) -> str | None:
+        """
+        Write a session_summary.json with status='incomplete' when the app closes
+        without a full session completion.
+
+        This allows metrics from the current visit to be preserved even if the
+        session is never resumed and completed.
+
+        Does NOT record to global_stats.json — only full completions do that.
+
+        Returns path to written file, or None on failure.
+        """
+        if not self.is_session_active():
+            return None
+
+        summary_path = self._get_summary_file_path()
+
+        # Don't overwrite an existing completed summary
+        if os.path.exists(summary_path):
+            try:
+                with open(summary_path, 'r', encoding='utf-8') as f:
+                    existing = json.load(f)
+                if existing.get('status') == 'completed':
+                    logger.debug("Completed summary already exists, skipping partial write")
+                    return None
+            except Exception:
+                pass  # Overwrite if unreadable
+
+        try:
+            summary = self.generate_session_summary(
+                worker_id=worker_id,
+                worker_name=worker_name,
+                session_type=session_type
+            )
+            summary['status'] = 'incomplete'
+
+            with open(summary_path, 'w', encoding='utf-8') as f:
+                json.dump(summary, f, indent=2, ensure_ascii=False)
+
+            completed = len(self.session_packing_state.get('completed_orders', []))
+            logger.info(
+                f"Partial session summary saved ({completed} completed orders): {summary_path}"
+            )
+            return summary_path
+
+        except Exception as e:
+            logger.error(f"Failed to save partial summary: {e}", exc_info=True)
+            return None
 
     def end_session_cleanup(self):
         """

--- a/src/session_browser/session_cache_manager.py
+++ b/src/session_browser/session_cache_manager.py
@@ -1,342 +1,263 @@
 """
-Session cache manager for persistent session data caching.
+Session cache manager — backed by local SQLite.
 
-This module provides disk-based caching of session scan results to enable
-instant Session Browser opening. Cache is stored as JSON and includes
-timestamp metadata for staleness detection.
+Replaces the old .session_browser_cache.json approach with a per-PC SQLite DB
+located in %%APPDATA%%\\PackingTool\\local_cache.db.
 
-Cache Location: {sessions_root}/.session_browser_cache.json
-Cache TTL: 300 seconds (5 minutes)
-
-Author: Claude Code
-Created: 2025-12-11
+TTL per status:
+  completed   → 3600 s (1 hour)   — immutable once written
+  available   → 300 s  (5 min)    — same as before
+  in_progress → 30 s              — must stay fresh (heartbeat is 60 s)
 """
 
-import json
 import time
+import sys
+import os
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Optional
+
+# Allow importing from parent src/ when running standalone
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from local_db import LocalDB, CACHE_TTL_COMPLETED, CACHE_TTL_AVAILABLE, CACHE_TTL_IN_PROGRESS
 from logger import get_logger
 
 logger = get_logger(__name__)
 
+_STATUS_TTL = {
+    "completed":   CACHE_TTL_COMPLETED,
+    "available":   CACHE_TTL_AVAILABLE,
+    "in_progress": CACHE_TTL_IN_PROGRESS,
+}
+
 
 class SessionCacheManager:
     """
-    Manages persistent caching of session scan results.
+    Manages persistent local caching of session scan results via SQLite.
 
-    Features:
-    - Disk-based cache (survives app restarts)
-    - Per-client caching with timestamps
-    - Automatic staleness detection
-    - Thread-safe read/write operations
-
-    Cache Structure:
-    {
-        "version": "1.0",
-        "last_updated": 1234567890.123,
-        "clients": {
-            "ALMADERM": {
-                "active": [...],
-                "completed": [...],
-                "available": [...],
-                "timestamp": 1234567890.123
-            }
-        }
-    }
+    Public API is intentionally kept compatible with the old JSON-based version
+    so existing callers need minimal changes.
     """
 
-    CACHE_VERSION = "1.0"
-    CACHE_FILENAME = ".session_browser_cache.json"
-    CACHE_TTL = 300  # 5 minutes
-
-    def __init__(self, sessions_root: Path):
+    def __init__(self, sessions_root: Path, db: Optional[LocalDB] = None):
         """
-        Initialize cache manager.
-
         Args:
-            sessions_root: Root directory containing all session data
+            sessions_root: Root directory containing all session data (file server path).
+                           Kept for compatibility; no longer used for cache storage.
+            db: Optional LocalDB instance (injected for testing). If None, a default
+                instance pointing to %%APPDATA%%\\PackingTool\\local_cache.db is created.
         """
         self.sessions_root = sessions_root
-        self.cache_file = sessions_root / self.CACHE_FILENAME
+        self._db = db or LocalDB()
+        logger.info(f"SessionCacheManager initialized (SQLite: {self._db._path})")
 
-        logger.info(f"SessionCacheManager initialized: {self.cache_file}")
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
 
-    def get_cached_data(self, client_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    def get_cached_data(self, client_id: Optional[str] = None) -> Optional[dict]:
         """
-        Get cached session data for a specific client or all clients.
+        Return cached session data for a client (or all clients).
 
-        Args:
-            client_id: Client ID to retrieve (None = all clients)
-
-        Returns:
-            Cached data dict or None if cache miss/stale
-
-        Format:
-            {
-                "active": [...],
-                "completed": [...],
-                "available": [...],
-                "timestamp": 1234567890.123,
-                "is_stale": False
-            }
+        Returns dict with keys: active, completed, available, timestamp, is_stale
+        Returns None only if no data exists at all.
         """
         try:
-            if not self.cache_file.exists():
-                logger.debug("Cache file not found")
-                return None
-
-            # Load cache
-            with open(self.cache_file, 'r', encoding='utf-8') as f:
-                cache = json.load(f)
-
-            # Validate version
-            if cache.get('version') != self.CACHE_VERSION:
-                logger.warning(f"Cache version mismatch: {cache.get('version')} != {self.CACHE_VERSION}")
-                return None
-
-            # Get specific client or all clients
             if client_id:
-                client_data = cache.get('clients', {}).get(client_id)
-                if not client_data:
-                    logger.debug(f"No cached data for client {client_id}")
-                    return None
-
-                # Check staleness
-                age = time.time() - client_data.get('timestamp', 0)
-                is_stale = age > self.CACHE_TTL
-
-                logger.info(
-                    f"Cache {'STALE' if is_stale else 'HIT'} for {client_id}: "
-                    f"age={age:.1f}s, TTL={self.CACHE_TTL}s"
-                )
-
-                return {
-                    'active': client_data.get('active', []),
-                    'completed': client_data.get('completed', []),
-                    'available': client_data.get('available', []),
-                    'timestamp': client_data.get('timestamp'),
-                    'is_stale': is_stale
-                }
+                return self._get_client_data(client_id)
             else:
-                # Return all clients data
-                all_data = {
-                    'active': [],
-                    'completed': [],
-                    'available': [],
-                    'timestamp': cache.get('last_updated', 0),
-                    'is_stale': False
-                }
-
-                # Aggregate from all clients
-                for cid, cdata in cache.get('clients', {}).items():
-                    all_data['active'].extend(cdata.get('active', []))
-                    all_data['completed'].extend(cdata.get('completed', []))
-                    all_data['available'].extend(cdata.get('available', []))
-
-                # Check overall staleness
-                age = time.time() - cache.get('last_updated', 0)
-                all_data['is_stale'] = age > self.CACHE_TTL
-
-                logger.info(
-                    f"Cache {'STALE' if all_data['is_stale'] else 'HIT'}: "
-                    f"age={age:.1f}s, {len(all_data['active'])} active, "
-                    f"{len(all_data['completed'])} completed, {len(all_data['available'])} available"
-                )
-
-                return all_data
-
-        except json.JSONDecodeError as e:
-            logger.error(f"Cache file corrupted: {e}")
-            return None
-
+                return self._get_all_clients_data()
         except Exception as e:
             logger.error(f"Failed to read cache: {e}", exc_info=True)
             return None
 
+    def _get_client_data(self, client_id: str) -> Optional[dict]:
+        active    = self._db.get_sessions_by_status(client_id, "in_progress")
+        completed = self._db.get_sessions_by_status(client_id, "completed")
+        available = self._db.get_sessions_by_status(client_id, "available")
+
+        if not (active or completed or available):
+            logger.debug(f"No cached data for client {client_id}")
+            return None
+
+        # Staleness: any status group is stale if its oldest row exceeds TTL.
+        # We report overall staleness based on the shortest-TTL populated group.
+        is_stale = self._is_any_group_stale(client_id)
+        oldest_ts = self._oldest_timestamp(active + completed + available)
+
+        logger.info(
+            f"Cache {'STALE' if is_stale else 'HIT'} for {client_id}: "
+            f"{len(active)} active, {len(completed)} completed, {len(available)} available"
+        )
+        return {
+            "active":    active,
+            "completed": completed,
+            "available": available,
+            "timestamp": oldest_ts,
+            "is_stale":  is_stale,
+        }
+
+    def _get_all_clients_data(self) -> dict:
+        # We don't have a dedicated "all clients" query; collect via per-status
+        # queries across all known clients in the DB.
+        with self._db._connect() as conn:
+            rows = conn.execute("SELECT DISTINCT client_id FROM session_cache").fetchall()
+        all_clients = [r["client_id"] for r in rows]
+
+        active, completed, available = [], [], []
+        is_stale = False
+        for cid in all_clients:
+            active    += self._db.get_sessions_by_status(cid, "in_progress")
+            completed += self._db.get_sessions_by_status(cid, "completed")
+            available += self._db.get_sessions_by_status(cid, "available")
+            if self._is_any_group_stale(cid):
+                is_stale = True
+
+        oldest_ts = self._oldest_timestamp(active + completed + available)
+        logger.info(
+            f"Cache {'STALE' if is_stale else 'HIT'} (all): "
+            f"{len(active)} active, {len(completed)} completed, {len(available)} available"
+        )
+        return {
+            "active":    active,
+            "completed": completed,
+            "available": available,
+            "timestamp": oldest_ts,
+            "is_stale":  is_stale,
+        }
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
     def save_cached_data(
         self,
-        active_data: List[dict],
-        completed_data: List[dict],
-        available_data: List[dict],
-        client_id: Optional[str] = None
+        active_data: list,
+        completed_data: list,
+        available_data: list,
+        client_id: Optional[str] = None,
     ):
         """
-        Save session scan results to cache.
+        Persist scan results to SQLite.
 
-        Args:
-            active_data: List of active session records
-            completed_data: List of completed session records
-            available_data: List of available session records
-            client_id: Client ID (None = all clients aggregated)
+        Accepts both plain dicts and SessionHistoryRecord objects (same as before).
         """
         try:
-            # Load existing cache or create new
-            if self.cache_file.exists():
-                with open(self.cache_file, 'r', encoding='utf-8') as f:
-                    cache = json.load(f)
-            else:
-                cache = {
-                    'version': self.CACHE_VERSION,
-                    'last_updated': 0,
-                    'clients': {}
-                }
+            rows = []
+            for status, records in (
+                ("in_progress", active_data),
+                ("completed",   completed_data),
+                ("available",   available_data),
+            ):
+                for record in records:
+                    d = self._to_dict(record, status)
+                    if client_id and not d.get("client_id"):
+                        d["client_id"] = client_id
+                    rows.append(d)
 
-            current_time = time.time()
-
-            # Helper to extract client_id from record (dict or object)
-            def get_client_id(record):
-                if isinstance(record, dict):
-                    return record.get('client_id', 'UNKNOWN')
-                else:
-                    # SessionHistoryRecord object
-                    return getattr(record, 'client_id', 'UNKNOWN')
-
-            # Helper to convert record to dict if needed
-            def to_dict(record):
-                if isinstance(record, dict):
-                    return record
-                else:
-                    # SessionHistoryRecord object - convert to dict
-                    return {
-                        'session_id': getattr(record, 'session_id', ''),
-                        'client_id': getattr(record, 'client_id', ''),
-                        'packing_list_path': getattr(record, 'packing_list_path', ''),
-                        'pc_name': getattr(record, 'pc_name', ''),
-                        'start_time': getattr(record, 'start_time', None).isoformat() if hasattr(record, 'start_time') and record.start_time else None,
-                        'end_time': getattr(record, 'end_time', None).isoformat() if hasattr(record, 'end_time') and record.end_time else None,
-                        'duration_seconds': getattr(record, 'duration_seconds', 0),
-                        'total_orders': getattr(record, 'total_orders', 0),
-                        'completed_orders': getattr(record, 'completed_orders', 0),
-                        'total_items_packed': getattr(record, 'total_items_packed', 0),
-                        'session_path': getattr(record, 'session_path', ''),
-                    }
-
-            # Update cache
-            if client_id:
-                # Update specific client
-                cache['clients'][client_id] = {
-                    'active': [to_dict(r) for r in active_data],
-                    'completed': [to_dict(r) for r in completed_data],
-                    'available': [to_dict(r) for r in available_data],
-                    'timestamp': current_time
-                }
-            else:
-                # Group by client_id from data
-                clients_data: Dict[str, Dict[str, List]] = {}
-
-                for record in active_data:
-                    cid = get_client_id(record)
-                    if cid not in clients_data:
-                        clients_data[cid] = {'active': [], 'completed': [], 'available': []}
-                    clients_data[cid]['active'].append(to_dict(record))
-
-                for record in completed_data:
-                    cid = get_client_id(record)
-                    if cid not in clients_data:
-                        clients_data[cid] = {'active': [], 'completed': [], 'available': []}
-                    clients_data[cid]['completed'].append(to_dict(record))
-
-                for record in available_data:
-                    cid = get_client_id(record)
-                    if cid not in clients_data:
-                        clients_data[cid] = {'active': [], 'completed': [], 'available': []}
-                    clients_data[cid]['available'].append(to_dict(record))
-
-                # Update all clients
-                for cid, data in clients_data.items():
-                    cache['clients'][cid] = {
-                        'active': data['active'],
-                        'completed': data['completed'],
-                        'available': data['available'],
-                        'timestamp': current_time
-                    }
-
-            cache['last_updated'] = current_time
-
-            # Write to disk (atomic write)
-            import tempfile
-            import shutil
-            with tempfile.NamedTemporaryFile(
-                mode='w',
-                encoding='utf-8',
-                suffix='.json',
-                dir=self.sessions_root,
-                delete=False
-            ) as tmp_file:
-                json.dump(cache, tmp_file, indent=2, ensure_ascii=False)
-                tmp_path = tmp_file.name
-
-            # Atomic replace
-            shutil.move(tmp_path, self.cache_file)
-
+            self._db.upsert_sessions(rows)
             logger.info(
                 f"Cache saved: {len(active_data)} active, {len(completed_data)} completed, "
                 f"{len(available_data)} available"
             )
-
         except Exception as e:
             logger.error(f"Failed to save cache: {e}", exc_info=True)
 
+    # ------------------------------------------------------------------
+    # Maintenance
+    # ------------------------------------------------------------------
+
     def clear_cache(self):
-        """Clear cache file."""
+        """Clear all cached data (equivalent to old cache file deletion)."""
         try:
-            if self.cache_file.exists():
-                self.cache_file.unlink()
-                logger.info("Cache cleared")
+            self._db.clear_all()
+            logger.info("Cache cleared")
         except Exception as e:
             logger.error(f"Failed to clear cache: {e}")
 
-    def get_cache_stats(self) -> Dict[str, Any]:
-        """
-        Get cache statistics.
-
-        Returns:
-            {
-                'exists': bool,
-                'age_seconds': float,
-                'is_stale': bool,
-                'clients_count': int,
-                'total_sessions': int
-            }
-        """
+    def get_cache_stats(self) -> dict:
+        """Return cache statistics (compatible with old API)."""
         try:
-            if not self.cache_file.exists():
-                return {
-                    'exists': False,
-                    'age_seconds': 0,
-                    'is_stale': True,
-                    'clients_count': 0,
-                    'total_sessions': 0
-                }
+            with self._db._connect() as conn:
+                rows = conn.execute(
+                    "SELECT status, COUNT(*) as cnt, MIN(last_synced) as oldest "
+                    "FROM session_cache GROUP BY status"
+                ).fetchall()
 
-            with open(self.cache_file, 'r', encoding='utf-8') as f:
-                cache = json.load(f)
+            if not rows:
+                return {"exists": False, "age_seconds": 0, "is_stale": True,
+                        "clients_count": 0, "total_sessions": 0}
 
-            last_updated = cache.get('last_updated', 0)
-            age = time.time() - last_updated
-            is_stale = age > self.CACHE_TTL
+            now = time.time()
+            oldest_synced = min(r["oldest"] for r in rows)
+            age = now - oldest_synced
+            total = sum(r["cnt"] for r in rows)
 
-            clients_count = len(cache.get('clients', {}))
-            total_sessions = sum(
-                len(c.get('active', [])) + len(c.get('completed', [])) + len(c.get('available', []))
-                for c in cache.get('clients', {}).values()
+            with self._db._connect() as conn:
+                clients_count = conn.execute(
+                    "SELECT COUNT(DISTINCT client_id) FROM session_cache"
+                ).fetchone()[0]
+
+            is_stale = any(
+                (now - r["oldest"]) > _STATUS_TTL.get(r["status"], CACHE_TTL_AVAILABLE)
+                for r in rows
             )
 
             return {
-                'exists': True,
-                'age_seconds': age,
-                'is_stale': is_stale,
-                'clients_count': clients_count,
-                'total_sessions': total_sessions
+                "exists": True,
+                "age_seconds": age,
+                "is_stale": is_stale,
+                "clients_count": clients_count,
+                "total_sessions": total,
             }
-
         except Exception as e:
             logger.error(f"Failed to get cache stats: {e}")
-            return {
-                'exists': False,
-                'age_seconds': 0,
-                'is_stale': True,
-                'clients_count': 0,
-                'total_sessions': 0
+            return {"exists": False, "age_seconds": 0, "is_stale": True,
+                    "clients_count": 0, "total_sessions": 0}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _is_any_group_stale(self, client_id: str) -> bool:
+        now = time.time()
+        for status, ttl in _STATUS_TTL.items():
+            rows = self._db.get_sessions_by_status(client_id, status)
+            if rows:
+                oldest = min(r["last_synced"] for r in rows)
+                if (now - oldest) > ttl:
+                    return True
+        return False
+
+    @staticmethod
+    def _oldest_timestamp(rows: list) -> float:
+        if not rows:
+            return 0.0
+        return min(r.get("last_synced", 0) for r in rows)
+
+    @staticmethod
+    def _to_dict(record, status: str) -> dict:
+        """Normalise a record (dict or SessionHistoryRecord) into a DB-ready dict."""
+        if isinstance(record, dict):
+            d = dict(record)
+        else:
+            # SessionHistoryRecord object
+            st = getattr(record, "start_time", None)
+            et = getattr(record, "end_time", None)
+            d = {
+                "session_id":        getattr(record, "session_id", ""),
+                "client_id":         getattr(record, "client_id", ""),
+                "session_path":      getattr(record, "session_path", ""),
+                "packing_list_name": getattr(record, "packing_list_path", ""),
+                "pc_name":           getattr(record, "pc_name", ""),
+                "start_time":        st.isoformat() if st else None,
+                "end_time":          et.isoformat() if et else None,
+                "duration_seconds":  getattr(record, "duration_seconds", 0),
+                "total_orders":      getattr(record, "total_orders", 0),
+                "completed_orders":  getattr(record, "completed_orders", 0),
+                "total_items_packed":getattr(record, "total_items_packed", 0),
             }
+        d["status"] = status
+        if not d.get("session_path"):
+            d["session_path"] = d.get("packing_list_path", "")
+        return d


### PR DESCRIPTION
- Add src/local_db.py — per-PC SQLite cache (%APPDATA%\PackingTool\local_cache.db) with smart TTL: completed=1h, available=5min, in_progress=30s

- Migrate SessionCacheManager from .session_browser_cache.json to SQLite; public API remains compatible with all existing callers

- Fix critical metrics bug: timing variables were initialised AFTER _load_session_state(), overwriting restored completed_orders_metadata on session resume — moved initialisation before the load call

- Add save_state() public alias (closeEvent was silently failing — method did not exist), is_session_active(), and save_partial_summary() which writes session_summary.json with status='incomplete' on app close

- Add excess item detection: SKU_EXCESS_TRACKED status, per-order current_order_excess_scans list, confirm/cancel helpers, and _handle_excess_scan() dialog in main.py (Ukrainian UI labels)

- Simplify active sessions tab: remove packing_state.json reads from list view; replace "Orders Progress" column with "Active For" elapsed time derived from lock age (no network reads in scan loop)

## Summary by Sourcery

Introduce a local SQLite-based session cache, improve session lifecycle persistence and metrics, and add UX for handling excess item scans and simplified active session monitoring.

New Features:
- Add a per-PC SQLite-backed LocalDB and wire SessionCacheManager to use it with status-specific TTLs for session caching.
- Add excess item detection and tracking for orders, including new SKU_EXCESS_TRACKED status, per-order excess scan storage, and UI dialog to confirm or cancel completing orders with excess scans.
- Persist partial session summaries with status='incomplete' on app close to retain metrics for unfinished sessions.

Bug Fixes:
- Initialize order timing and completed_orders_metadata before loading session state to avoid overwriting restored timing data on session resume.
- Ensure closeEvent successfully saves packing state by providing a public save_state alias for the internal session save method.

Enhancements:
- Expose helpers on PackerLogic to inspect session activity and manage excess scans, including confirming completion and cancelling excess entries.
- Simplify the Active Sessions tab by removing packing_state.json reads and replacing progress percentage with an 'Active For' duration derived from lock age.