### PR TITLE
fix: bundle dark/light QSS themes in PyInstaller exe and fix path res…

### DIFF
--- a/main.spec
+++ b/main.spec
@@ -1,4 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
+from glob import glob
 
 
 a = Analysis(
@@ -6,9 +7,7 @@ a = Analysis(
     pathex=['src', '.'],  # Added '.' for project root (to find 'shared' module)
     binaries=[],
     datas=[
-        ('src/styles.qss', 'src'),
-        ('src/styles_dark.qss', 'src'),
-        ('src/styles_light.qss', 'src'),
+        *[(qss, 'src') for qss in glob('src/*.qss')],
         ('config.ini.example', '.'),
         ('shared', 'shared'),  # Include shared module directory
     ],

--- a/main.spec
+++ b/main.spec
@@ -7,6 +7,8 @@ a = Analysis(
     binaries=[],
     datas=[
         ('src/styles.qss', 'src'),
+        ('src/styles_dark.qss', 'src'),
+        ('src/styles_light.qss', 'src'),
         ('config.ini.example', '.'),
         ('shared', 'shared'),  # Include shared module directory
     ],

--- a/src/theme.py
+++ b/src/theme.py
@@ -6,6 +6,7 @@ rendering (labels, window backgrounds, etc.) also uses the correct colors.
 """
 
 import logging
+import sys
 from pathlib import Path
 from PySide6.QtWidgets import QApplication
 from PySide6.QtCore import QSettings
@@ -16,7 +17,13 @@ THEME_LIGHT = "light"
 
 
 def _load_qss(filename: str) -> str:
-    qss_path = Path(__file__).parent / filename
+    # In a PyInstaller exe, bundled data files are extracted to sys._MEIPASS/src/
+    # When running from source, fall back to the directory of this file
+    if getattr(sys, "frozen", False):
+        base = Path(sys._MEIPASS) / "src"
+    else:
+        base = Path(__file__).parent
+    qss_path = base / filename
     if qss_path.exists():
         return qss_path.read_text(encoding="utf-8")
     logging.warning("QSS theme file not found: %s", qss_path)

--- a/src/theme.py
+++ b/src/theme.py
@@ -19,7 +19,7 @@ THEME_LIGHT = "light"
 def _load_qss(filename: str) -> str:
     # In a PyInstaller exe, bundled data files are extracted to sys._MEIPASS/src/
     # When running from source, fall back to the directory of this file
-    if getattr(sys, "frozen", False):
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
         base = Path(sys._MEIPASS) / "src"
     else:
         base = Path(__file__).parent


### PR DESCRIPTION
…olution

Added styles_dark.qss and styles_light.qss to main.spec datas so they are included in the compiled exe. Fixed _load_qss() in theme.py to use sys._MEIPASS when running frozen instead of __file__.parent which pointed to the wrong location inside the PyInstaller archive.

## Summary by Sourcery

Ensure QSS themes are correctly located and bundled when running the app as a PyInstaller executable.

Bug Fixes:
- Fix QSS theme loading to resolve the correct path when running from a PyInstaller-frozen executable.

Build:
- Bundle dark and light QSS theme files in the PyInstaller build so they are available in the packaged executable.