### PR TITLE
feat: packer mode comprehensive upgrade — metadata, skip, force, prog…

### DIFF
--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -1155,17 +1155,22 @@ class PackerLogic(QObject):
                 continue
 
             # Extract Shopify metadata fields for this order
+            # Handle field name variants between analysis_data.json and packing_lists
             internal_tags_raw = order.get('internal_tags', [])
             tags_raw = order.get('tags', [])
+            tags_list = tags_raw if isinstance(tags_raw, list) else [tags_raw] if tags_raw else []
+            tags_list = [str(t) for t in tags_list if t and str(t).lower() not in ('nan', 'none')]
             order_metadata_map[order_number] = {
                 'system_note': order.get('system_note', ''),
                 'status_note': order.get('status_note', ''),
                 'internal_tags': internal_tags_raw if isinstance(internal_tags_raw, list) else [internal_tags_raw] if internal_tags_raw else [],
-                'tags': tags_raw if isinstance(tags_raw, list) else [tags_raw] if tags_raw else [],
+                'tags': tags_list,
                 'created_at': order.get('created_at', ''),
-                'status': order.get('status', ''),
-                'recommended_box': order.get('recommended_box', ''),
+                'status': order.get('status', '') or order.get('fulfillment_status', ''),
+                'recommended_box': order.get('recommended_box', '') or order.get('min_box', ''),
                 'shipping_method': order.get('shipping_method', ''),
+                'destination': order.get('destination', '') or order.get('shipping_country', ''),
+                'order_type': order.get('order_type', ''),
                 'courier': courier,
             }
 
@@ -1183,7 +1188,9 @@ class PackerLogic(QObject):
                 for key, value in order.items():
                     if key not in ['order_number', 'courier', 'items', 'system_note',
                                    'status_note', 'internal_tags', 'tags', 'created_at',
-                                   'status', 'recommended_box', 'shipping_method']:
+                                   'status', 'fulfillment_status', 'recommended_box',
+                                   'min_box', 'shipping_method', 'destination',
+                                   'shipping_country', 'order_type']:
                         # Capitalize key to match packing list style
                         formatted_key = key.replace('_', ' ').title().replace(' ', '_')
                         row[formatted_key] = str(value)
@@ -1346,17 +1353,22 @@ class PackerLogic(QObject):
             items = order.get('items', [])
 
             # Extract Shopify metadata fields for this order
+            # Handle field name variants between analysis_data.json and packing_lists
             internal_tags_raw = order.get('internal_tags', [])
             tags_raw = order.get('tags', [])
+            tags_list = tags_raw if isinstance(tags_raw, list) else [tags_raw] if tags_raw else []
+            tags_list = [str(t) for t in tags_list if t and str(t).lower() not in ('nan', 'none')]
             order_metadata_map[order_number] = {
                 'system_note': order.get('system_note', ''),
                 'status_note': order.get('status_note', ''),
                 'internal_tags': internal_tags_raw if isinstance(internal_tags_raw, list) else [internal_tags_raw] if internal_tags_raw else [],
-                'tags': tags_raw if isinstance(tags_raw, list) else [tags_raw] if tags_raw else [],
+                'tags': tags_list,
                 'created_at': order.get('created_at', ''),
-                'status': order.get('status', ''),
-                'recommended_box': order.get('recommended_box', ''),
+                'status': order.get('status', '') or order.get('fulfillment_status', ''),
+                'recommended_box': order.get('recommended_box', '') or order.get('min_box', ''),
                 'shipping_method': order.get('shipping_method', ''),
+                'destination': order.get('destination', '') or order.get('shipping_country', ''),
+                'order_type': order.get('order_type', ''),
                 'courier': courier,
             }
 

--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -1024,8 +1024,8 @@ class PackerLogic(QObject):
         """
         Returns the Shopify metadata dict for the given order.
 
-        Contains: system_note, internal_tags, tags, created_at, status,
-                  recommended_box, shipping_method, courier.
+        Contains: system_note, status_note, internal_tags, tags, created_at,
+                  status, shopify_status, recommended_box, destination, courier.
 
         Returns an empty dict if the order is not found or has no metadata.
         """
@@ -1167,10 +1167,9 @@ class PackerLogic(QObject):
                 'tags': tags_list,
                 'created_at': order.get('created_at', ''),
                 'status': order.get('status', '') or order.get('fulfillment_status', ''),
+                'shopify_status': order.get('shopify_status', ''),
                 'recommended_box': order.get('recommended_box', '') or order.get('min_box', ''),
-                'shipping_method': order.get('shipping_method', ''),
                 'destination': order.get('destination', '') or order.get('shipping_country', ''),
-                'order_type': order.get('order_type', ''),
                 'courier': courier,
             }
 
@@ -1188,9 +1187,9 @@ class PackerLogic(QObject):
                 for key, value in order.items():
                     if key not in ['order_number', 'courier', 'items', 'system_note',
                                    'status_note', 'internal_tags', 'tags', 'created_at',
-                                   'status', 'fulfillment_status', 'recommended_box',
-                                   'min_box', 'shipping_method', 'destination',
-                                   'shipping_country', 'order_type']:
+                                   'status', 'fulfillment_status', 'shopify_status',
+                                   'recommended_box', 'min_box', 'destination',
+                                   'shipping_country']:
                         # Capitalize key to match packing list style
                         formatted_key = key.replace('_', ' ').title().replace(' ', '_')
                         row[formatted_key] = str(value)
@@ -1365,10 +1364,9 @@ class PackerLogic(QObject):
                 'tags': tags_list,
                 'created_at': order.get('created_at', ''),
                 'status': order.get('status', '') or order.get('fulfillment_status', ''),
+                'shopify_status': order.get('shopify_status', ''),
                 'recommended_box': order.get('recommended_box', '') or order.get('min_box', ''),
-                'shipping_method': order.get('shipping_method', ''),
                 'destination': order.get('destination', '') or order.get('shipping_country', ''),
-                'order_type': order.get('order_type', ''),
                 'courier': courier,
             }
 
@@ -1385,8 +1383,9 @@ class PackerLogic(QObject):
                 # (e.g., customer name, address, etc.)
                 for key, value in order.items():
                     if key not in ['order_number', 'courier', 'items', 'status',
-                                   'system_note', 'internal_tags', 'tags', 'created_at',
-                                   'recommended_box', 'shipping_method']:
+                                   'system_note', 'status_note', 'internal_tags',
+                                   'tags', 'created_at', 'shopify_status',
+                                   'recommended_box', 'destination', 'shipping_country']:
                         # Capitalize key to match packing list style
                         formatted_key = key.replace('_', ' ').title().replace(' ', '_')
                         row[formatted_key] = str(value)

--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -1159,6 +1159,7 @@ class PackerLogic(QObject):
             tags_raw = order.get('tags', [])
             order_metadata_map[order_number] = {
                 'system_note': order.get('system_note', ''),
+                'status_note': order.get('status_note', ''),
                 'internal_tags': internal_tags_raw if isinstance(internal_tags_raw, list) else [internal_tags_raw] if internal_tags_raw else [],
                 'tags': tags_raw if isinstance(tags_raw, list) else [tags_raw] if tags_raw else [],
                 'created_at': order.get('created_at', ''),
@@ -1181,8 +1182,8 @@ class PackerLogic(QObject):
                 # (e.g., customer name, address, tracking number, etc.)
                 for key, value in order.items():
                     if key not in ['order_number', 'courier', 'items', 'system_note',
-                                   'internal_tags', 'tags', 'created_at', 'status',
-                                   'recommended_box', 'shipping_method']:
+                                   'status_note', 'internal_tags', 'tags', 'created_at',
+                                   'status', 'recommended_box', 'shipping_method']:
                         # Capitalize key to match packing list style
                         formatted_key = key.replace('_', ' ').title().replace(' ', '_')
                         row[formatted_key] = str(value)
@@ -1349,6 +1350,7 @@ class PackerLogic(QObject):
             tags_raw = order.get('tags', [])
             order_metadata_map[order_number] = {
                 'system_note': order.get('system_note', ''),
+                'status_note': order.get('status_note', ''),
                 'internal_tags': internal_tags_raw if isinstance(internal_tags_raw, list) else [internal_tags_raw] if internal_tags_raw else [],
                 'tags': tags_raw if isinstance(tags_raw, list) else [tags_raw] if tags_raw else [],
                 'created_at': order.get('created_at', ''),

--- a/src/packer_mode_widget.py
+++ b/src/packer_mode_widget.py
@@ -21,13 +21,14 @@ COURIER_COLORS = {
 }
 DEFAULT_COURIER_COLOR = ('#555555', '#ffffff')
 
-# Fulfillment status -> badge color
-STATUS_COLORS = {
-    'Fulfillable':   ('#1b5e20', '#a5d6a7'),
-    'Unfulfillable': ('#b71c1c', '#ef9a9a'),
-    'Fulfilled':     ('#0d47a1', '#90caf9'),
+# Shopify fulfillment status -> badge color
+SHOPIFY_STATUS_COLORS = {
+    'fulfilled':           ('#0d47a1', '#90caf9'),
+    'unfulfilled':         ('#b71c1c', '#ef9a9a'),
+    'partially_fulfilled': ('#e65100', '#ffcc80'),
+    'partial':             ('#e65100', '#ffcc80'),
 }
-DEFAULT_STATUS_COLOR = ('#424242', '#bdbdbd')
+DEFAULT_SHOPIFY_STATUS_COLOR = ('#424242', '#bdbdbd')
 
 _BADGE_STYLE = (
     "border-radius: 4px; padding: 2px 8px; font-weight: bold; font-size: 11px;"
@@ -297,9 +298,9 @@ class PackerModeWidget(QWidget):
         meta_layout.setContentsMargins(8, 4, 8, 4)
         meta_layout.setSpacing(8)
 
-        self.meta_status_label = QLabel()
-        self.meta_status_label.setVisible(False)
-        meta_layout.addWidget(self.meta_status_label)
+        self.meta_shopify_status_label = QLabel()
+        self.meta_shopify_status_label.setVisible(False)
+        meta_layout.addWidget(self.meta_shopify_status_label)
 
         self.meta_courier_label = QLabel()
         self.meta_courier_label.setVisible(False)
@@ -309,10 +310,6 @@ class PackerModeWidget(QWidget):
         self.meta_destination_label.setVisible(False)
         meta_layout.addWidget(self.meta_destination_label)
 
-        self.meta_order_type_label = QLabel()
-        self.meta_order_type_label.setVisible(False)
-        meta_layout.addWidget(self.meta_order_type_label)
-
         sep1 = QFrame(); sep1.setFrameShape(QFrame.Shape.VLine)
         sep1.setFrameShadow(QFrame.Shadow.Sunken)
         meta_layout.addWidget(sep1)
@@ -320,10 +317,6 @@ class PackerModeWidget(QWidget):
         self.meta_box_label = QLabel()
         self.meta_box_label.setVisible(False)
         meta_layout.addWidget(self.meta_box_label)
-
-        self.meta_method_label = QLabel()
-        self.meta_method_label.setVisible(False)
-        meta_layout.addWidget(self.meta_method_label)
 
         self.meta_created_label = QLabel()
         self.meta_created_label.setVisible(False)
@@ -400,17 +393,18 @@ class PackerModeWidget(QWidget):
 
     def display_order_metadata(self, metadata: dict, courier: str = ''):
         """Populates and shows the order metadata strip at the bottom."""
-        # Status badge
-        status = metadata.get('status', '')
-        if status:
-            bg, fg = STATUS_COLORS.get(status, DEFAULT_STATUS_COLOR)
-            self.meta_status_label.setText(status)
-            self.meta_status_label.setStyleSheet(
+        # Shopify fulfillment status badge
+        shopify_status = metadata.get('shopify_status', '')
+        if shopify_status:
+            key = shopify_status.lower().replace(' ', '_')
+            bg, fg = SHOPIFY_STATUS_COLORS.get(key, DEFAULT_SHOPIFY_STATUS_COLOR)
+            self.meta_shopify_status_label.setText(shopify_status)
+            self.meta_shopify_status_label.setStyleSheet(
                 f"background-color: {bg}; color: {fg}; {_BADGE_STYLE}"
             )
-            self.meta_status_label.setVisible(True)
+            self.meta_shopify_status_label.setVisible(True)
         else:
-            self.meta_status_label.setVisible(False)
+            self.meta_shopify_status_label.setVisible(False)
 
         # Courier badge
         courier_name = courier or metadata.get('courier', '')
@@ -435,19 +429,6 @@ class PackerModeWidget(QWidget):
         else:
             self.meta_destination_label.setVisible(False)
 
-        # Order type (Single/Multi)
-        order_type = metadata.get('order_type', '')
-        if order_type:
-            ot_bg = "#4a148c" if order_type == "Multi" else "#1b5e20"
-            ot_fg = "#ce93d8" if order_type == "Multi" else "#81c784"
-            self.meta_order_type_label.setText(order_type)
-            self.meta_order_type_label.setStyleSheet(
-                f"background-color: {ot_bg}; color: {ot_fg}; {_BADGE_STYLE}"
-            )
-            self.meta_order_type_label.setVisible(True)
-        else:
-            self.meta_order_type_label.setVisible(False)
-
         # Recommended box
         box = metadata.get('recommended_box', '')
         if box:
@@ -455,14 +436,6 @@ class PackerModeWidget(QWidget):
             self.meta_box_label.setVisible(True)
         else:
             self.meta_box_label.setVisible(False)
-
-        # Shipping method
-        method = metadata.get('shipping_method', '')
-        if method:
-            self.meta_method_label.setText(f"🚚 {method}")
-            self.meta_method_label.setVisible(True)
-        else:
-            self.meta_method_label.setVisible(False)
 
         # Created at (date only)
         created = metadata.get('created_at', '')

--- a/src/packer_mode_widget.py
+++ b/src/packer_mode_widget.py
@@ -3,60 +3,145 @@ from functools import partial
 from PySide6.QtWidgets import (
     QWidget, QHBoxLayout, QVBoxLayout, QTableWidget, QTableWidgetItem,
     QLabel, QLineEdit, QHeaderView, QPushButton, QAbstractItemView, QFrame,
-    QGroupBox
+    QGroupBox, QProgressBar, QSplitter, QScrollArea, QSizePolicy
 )
-from PySide6.QtGui import QFont, QColor, QPalette
+from PySide6.QtGui import QFont, QColor
 from PySide6.QtCore import Qt, Signal
 from typing import List, Dict, Any
 
 logger = logging.getLogger(__name__)
 
+# Courier -> badge color mapping (background, foreground)
+COURIER_COLORS = {
+    'DHL':      ('#c8a800', '#1a1a00'),
+    'PostOne':  ('#1565c0', '#e3f2fd'),
+    'Speedy':   ('#2e7d32', '#e8f5e9'),
+    'Nova':     ('#6a1b9a', '#f3e5f5'),
+    'Econt':    ('#00695c', '#e0f2f1'),
+}
+DEFAULT_COURIER_COLOR = ('#555555', '#ffffff')
+
+# Fulfillment status -> badge color
+STATUS_COLORS = {
+    'Fulfillable':   ('#1b5e20', '#a5d6a7'),
+    'Unfulfillable': ('#b71c1c', '#ef9a9a'),
+    'Fulfilled':     ('#0d47a1', '#90caf9'),
+}
+DEFAULT_STATUS_COLOR = ('#424242', '#bdbdbd')
+
+_BADGE_STYLE = (
+    "border-radius: 4px; padding: 2px 8px; font-weight: bold; font-size: 11px;"
+)
+
+
+def _make_badge(text: str, bg: str, fg: str) -> QLabel:
+    lbl = QLabel(text)
+    lbl.setStyleSheet(f"background-color: {bg}; color: {fg}; {_BADGE_STYLE}")
+    lbl.setAlignment(Qt.AlignCenter)
+    lbl.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+    return lbl
+
+
 class PackerModeWidget(QWidget):
     """
-    The user interface for the main "Packer Mode" screen.
+    Packer Mode UI — main screen for warehouse scanning.
 
-    This widget displays the items for the currently active order, provides
-    visual feedback on scanning actions, and captures input from a barcode
+    Layout:
+      [TOP]    Session progress bar + label           (full width)
+      [MAIN]   QSplitter horizontal:
+                 Left (resizable): items-to-pack summary table
+                 Center (stretch): SKU scan table
+                 Right (resizable): status / notification / skip / history / controls
+      [BOTTOM] Order metadata strip (hidden until order loaded):
+                 courier badge | status badge | box | method | date | tags | note
 
-    scanner. It is designed to be a dedicated, focused view for the packing
-    process.
-
-    Attributes:
-        barcode_scanned (Signal): Emitted when a barcode is scanned (i.e., when
-                                  Enter is pressed in the scanner_input).
-        exit_packing_mode (Signal): Emitted when the user clicks the exit button.
-        table_frame (QFrame): A frame around the items table used for flashing
-                              visual feedback (e.g., green/red border).
-        table (QTableWidget): The table displaying the SKUs for the current order.
-        status_label (QLabel): A label showing the current order's status.
-        notification_label (QLabel): A large label for showing prominent
-                                     notifications (e.g., "ORDER COMPLETE").
-        scanner_input (QLineEdit): A hidden line edit that captures keystrokes
-                                   from a USB barcode scanner.
-        raw_scan_label (QLabel): A label to display the raw text from the last scan.
-        history_table (QTableWidget): A table showing a history of scanned orders.
+    Signals:
+        barcode_scanned(str): Emitted when scanner fires.
+        exit_packing_mode():  Back to menu.
+        skip_order_requested(): Skip button clicked.
+        force_complete_sku(str): Force-complete a SKU row.
     """
+
     barcode_scanned = Signal(str)
     exit_packing_mode = Signal()
+    skip_order_requested = Signal()
+    force_complete_sku = Signal(str)
 
-    FRAME_DEFAULT_STYLE = "QFrame#TableFrame { border: 1px solid palette(mid); border-radius: 3px; }"
+    FRAME_DEFAULT_STYLE = (
+        "QFrame#TableFrame { border: 1px solid palette(mid); border-radius: 3px; }"
+    )
 
     def __init__(self, parent: QWidget = None, sim_mode: bool = False):
-        """
-        Initializes the PackerModeWidget and its UI components.
-
-        Args:
-            parent (QWidget, optional): The parent widget. Defaults to None.
-            sim_mode (bool): When True, show a visible scan simulator panel for
-                development/testing without a physical barcode scanner. Defaults to False.
-        """
         super().__init__(parent)
         self._sim_mode = sim_mode
 
-        main_layout = QHBoxLayout(self)
+        root_layout = QVBoxLayout(self)
+        root_layout.setSpacing(4)
+        root_layout.setContentsMargins(6, 4, 6, 4)
 
+        # ── TOP: SESSION PROGRESS STRIP ────────────────────────────────────────
+        top_strip = QFrame()
+        top_strip.setFrameShape(QFrame.Shape.StyledPanel)
+        top_strip.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        top_layout = QHBoxLayout(top_strip)
+        top_layout.setContentsMargins(8, 4, 8, 4)
+        top_layout.setSpacing(8)
+
+        prog_lbl = QLabel("Session:")
+        prog_lbl.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+        bold_font = QFont(); bold_font.setBold(True)
+        prog_lbl.setFont(bold_font)
+
+        self.session_progress_bar = QProgressBar()
+        self.session_progress_bar.setRange(0, 1)
+        self.session_progress_bar.setValue(0)
+        self.session_progress_bar.setFormat("%v / %m orders")
+        self.session_progress_bar.setAlignment(Qt.AlignCenter)
+        self.session_progress_bar.setTextVisible(True)
+        self.session_progress_bar.setFixedHeight(20)
+        self.session_progress_bar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+        self.session_progress_label = QLabel("0 of 0 completed")
+        self.session_progress_label.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+
+        top_layout.addWidget(prog_lbl)
+        top_layout.addWidget(self.session_progress_bar)
+        top_layout.addWidget(self.session_progress_label)
+        root_layout.addWidget(top_strip)
+
+        # ── MAIN: QSplitter (left summary | center table | right controls) ─────
+        self._main_splitter = QSplitter(Qt.Horizontal)
+        self._main_splitter.setChildrenCollapsible(False)
+
+        # ── LEFT: Items-to-pack summary ────────────────────────────────────────
         left_widget = QWidget()
+        left_widget.setMinimumWidth(160)
         left_layout = QVBoxLayout(left_widget)
+        left_layout.setContentsMargins(0, 0, 4, 0)
+        left_layout.setSpacing(4)
+
+        summary_title = QLabel("Items to Pack")
+        summary_title.setFont(bold_font)
+        left_layout.addWidget(summary_title)
+
+        self.summary_table = QTableWidget()
+        self.summary_table.setColumnCount(3)
+        self.summary_table.setHorizontalHeaderLabels(["SKU", "Product", "Qty"])
+        self.summary_table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeToContents)
+        self.summary_table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeToContents)
+        self.summary_table.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch)
+        self.summary_table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.summary_table.setSelectionMode(QAbstractItemView.NoSelection)
+        self.summary_table.setFocusPolicy(Qt.NoFocus)
+        self.summary_table.verticalHeader().setVisible(False)
+        left_layout.addWidget(self.summary_table, stretch=1)
+
+        self._main_splitter.addWidget(left_widget)
+
+        # ── CENTER: SKU scan table ─────────────────────────────────────────────
+        center_widget = QWidget()
+        center_layout = QVBoxLayout(center_widget)
+        center_layout.setContentsMargins(0, 0, 0, 0)
 
         self.table_frame = QFrame()
         self.table_frame.setObjectName("TableFrame")
@@ -67,24 +152,35 @@ class PackerModeWidget(QWidget):
         frame_layout.setContentsMargins(0, 0, 0, 0)
 
         self.table = QTableWidget()
-        self.table.setColumnCount(5)
-        self.table.setHorizontalHeaderLabels(["Product Name", "SKU", "Packed / Required", "Status", "Action"])
-        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
-        self.table.horizontalHeader().setStretchLastSection(True)
+        self.table.setColumnCount(6)
+        self.table.setHorizontalHeaderLabels(
+            ["Product Name", "SKU", "Packed / Required", "Status", "Confirm", "Force"]
+        )
+        self.table.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+        self.table.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeToContents)
+        self.table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeToContents)
+        self.table.horizontalHeader().setSectionResizeMode(3, QHeaderView.ResizeToContents)
+        self.table.horizontalHeader().setSectionResizeMode(4, QHeaderView.ResizeToContents)
+        self.table.horizontalHeader().setSectionResizeMode(5, QHeaderView.ResizeToContents)
         self.table.setEditTriggers(QTableWidget.NoEditTriggers)
         self.table.setSelectionMode(QAbstractItemView.NoSelection)
         self.table.setFocusPolicy(Qt.NoFocus)
+        self.table.verticalHeader().setDefaultSectionSize(34)
 
         frame_layout.addWidget(self.table)
-        left_layout.addWidget(self.table_frame)
+        center_layout.addWidget(self.table_frame)
 
+        self._main_splitter.addWidget(center_widget)
+
+        # ── RIGHT: Status / controls / history ────────────────────────────────
         right_widget = QWidget()
+        right_widget.setMinimumWidth(160)
         right_layout = QVBoxLayout(right_widget)
-        right_layout.setAlignment(Qt.AlignCenter)
+        right_layout.setContentsMargins(4, 0, 0, 0)
+        right_layout.setSpacing(6)
 
-        # Dev mode: visible scan simulator panel (replaces physical barcode scanner)
         if self._sim_mode:
-            sim_group = QGroupBox("Scan Simulator (Dev Mode)")
+            sim_group = QGroupBox("Scan Simulator")
             sim_group.setStyleSheet(
                 "QGroupBox { border: 2px dashed #e67e22; border-radius: 6px; "
                 "margin-top: 6px; padding: 4px; color: #e67e22; font-weight: bold; }"
@@ -92,30 +188,39 @@ class PackerModeWidget(QWidget):
             )
             sim_layout = QHBoxLayout(sim_group)
             self.sim_input = QLineEdit()
-            self.sim_input.setPlaceholderText("Type order number or SKU, press Enter to scan...")
+            self.sim_input.setPlaceholderText("Order # or SKU…")
             self.sim_input.returnPressed.connect(self._on_sim_scan)
             sim_btn = QPushButton("Scan")
-            sim_btn.setFixedWidth(70)
+            sim_btn.setFixedWidth(50)
             sim_btn.clicked.connect(self._on_sim_scan)
             sim_layout.addWidget(self.sim_input)
             sim_layout.addWidget(sim_btn)
             right_layout.addWidget(sim_group)
 
         self.status_label = QLabel("Scan an order barcode")
-        font = QFont(); font.setPointSize(20)
-        self.status_label.setFont(font)
+        status_font = QFont(); status_font.setPointSize(14)
+        self.status_label.setFont(status_font)
         self.status_label.setAlignment(Qt.AlignCenter)
         self.status_label.setWordWrap(True)
+        right_layout.addWidget(self.status_label)
 
         self.notification_label = QLabel("")
-        notif_font = QFont(); notif_font.setPointSize(32); notif_font.setBold(True)
+        notif_font = QFont(); notif_font.setPointSize(20); notif_font.setBold(True)
         self.notification_label.setFont(notif_font)
         self.notification_label.setAlignment(Qt.AlignCenter)
         self.notification_label.setWordWrap(True)
-
-        right_layout.addWidget(self.status_label)
         right_layout.addWidget(self.notification_label)
+
         right_layout.addStretch()
+
+        self.skip_button = QPushButton("⏭  Skip Order")
+        self.skip_button.setFocusPolicy(Qt.NoFocus)
+        self.skip_button.setEnabled(False)
+        self.skip_button.setToolTip(
+            "Skip current order. Progress is preserved — scan barcode to resume."
+        )
+        self.skip_button.clicked.connect(self.skip_order_requested.emit)
+        right_layout.addWidget(self.skip_button)
 
         raw_scan_title = QLabel("Last Scan:")
         raw_scan_title.setAlignment(Qt.AlignCenter)
@@ -123,199 +228,449 @@ class PackerModeWidget(QWidget):
         self.raw_scan_label.setAlignment(Qt.AlignCenter)
         self.raw_scan_label.setObjectName("RawScanLabel")
         self.raw_scan_label.setWordWrap(True)
+        right_layout.addWidget(raw_scan_title)
+        right_layout.addWidget(self.raw_scan_label)
 
-        history_title = QLabel("Scanned Orders History:")
+        history_title = QLabel("Scanned Orders:")
         history_title.setAlignment(Qt.AlignCenter)
+        right_layout.addWidget(history_title)
+
         self.history_table = QTableWidget()
-        self.history_table.setColumnCount(1)
-        self.history_table.setHorizontalHeaderLabels(["Order #"])
-        self.history_table.horizontalHeader().setStretchLastSection(True)
+        self.history_table.setColumnCount(2)
+        self.history_table.setHorizontalHeaderLabels(["Order #", "Items"])
+        self.history_table.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+        self.history_table.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeToContents)
         self.history_table.setEditTriggers(QTableWidget.NoEditTriggers)
         self.history_table.setSelectionMode(QAbstractItemView.NoSelection)
         self.history_table.setFocusPolicy(Qt.NoFocus)
+        self.history_table.verticalHeader().setVisible(False)
+        self.history_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        right_layout.addWidget(self.history_table, stretch=1)
 
-        info_container = QWidget()
-        info_layout = QVBoxLayout(info_container)
-        info_layout.setContentsMargins(0,0,0,0)
-        info_layout.addWidget(raw_scan_title)
-        info_layout.addWidget(self.raw_scan_label)
-        info_layout.addWidget(history_title)
-        info_layout.addWidget(self.history_table)
+        prev_title = QLabel("Previous Order Items:")
+        prev_title.setAlignment(Qt.AlignCenter)
+        prev_title_font = QFont(); prev_title_font.setPointSize(8)
+        prev_title.setFont(prev_title_font)
+        right_layout.addWidget(prev_title)
 
-        right_layout.addWidget(info_container)
-        right_layout.addStretch()
+        self.prev_order_table = QTableWidget()
+        self.prev_order_table.setColumnCount(2)
+        self.prev_order_table.setHorizontalHeaderLabels(["SKU", "Product"])
+        self.prev_order_table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeToContents)
+        self.prev_order_table.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch)
+        self.prev_order_table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.prev_order_table.setSelectionMode(QAbstractItemView.NoSelection)
+        self.prev_order_table.setFocusPolicy(Qt.NoFocus)
+        self.prev_order_table.verticalHeader().setVisible(False)
+        self.prev_order_table.setVisible(False)
+        self.prev_order_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        right_layout.addWidget(self.prev_order_table, stretch=1)
 
+        # Hidden scanner capture
         self.scanner_input = QLineEdit()
         self.scanner_input.setFixedSize(1, 1)
         self.scanner_input.returnPressed.connect(self._on_scan)
         right_layout.addWidget(self.scanner_input)
 
-        right_layout.addStretch()
         self.exit_button = QPushButton("<< Back to Menu")
-        font = self.exit_button.font(); font.setPointSize(14)
-        self.exit_button.setFont(font)
+        exit_font = self.exit_button.font(); exit_font.setPointSize(12)
+        self.exit_button.setFont(exit_font)
+        self.exit_button.setFocusPolicy(Qt.NoFocus)
         self.exit_button.clicked.connect(self.exit_packing_mode.emit)
         right_layout.addWidget(self.exit_button)
 
-        main_layout.addWidget(left_widget, stretch=2)
-        main_layout.addWidget(right_widget, stretch=1)
+        self._main_splitter.addWidget(right_widget)
+
+        # Splitter initial proportions: 1 : 4 : 1.5
+        self._main_splitter.setStretchFactor(0, 1)
+        self._main_splitter.setStretchFactor(1, 4)
+        self._main_splitter.setStretchFactor(2, 1)
+
+        root_layout.addWidget(self._main_splitter, stretch=1)
+
+        # ── BOTTOM: Order metadata strip (hidden until order loaded) ───────────
+        self.metadata_frame = QFrame()
+        self.metadata_frame.setFrameShape(QFrame.Shape.StyledPanel)
+        self.metadata_frame.setVisible(False)
+        self.metadata_frame.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        meta_layout = QHBoxLayout(self.metadata_frame)
+        meta_layout.setContentsMargins(8, 4, 8, 4)
+        meta_layout.setSpacing(8)
+
+        self.meta_status_label = QLabel()
+        self.meta_status_label.setVisible(False)
+        meta_layout.addWidget(self.meta_status_label)
+
+        self.meta_courier_label = QLabel()
+        self.meta_courier_label.setVisible(False)
+        meta_layout.addWidget(self.meta_courier_label)
+
+        sep1 = QFrame(); sep1.setFrameShape(QFrame.Shape.VLine)
+        sep1.setFrameShadow(QFrame.Shadow.Sunken)
+        meta_layout.addWidget(sep1)
+
+        self.meta_box_label = QLabel()
+        self.meta_box_label.setVisible(False)
+        meta_layout.addWidget(self.meta_box_label)
+
+        self.meta_method_label = QLabel()
+        self.meta_method_label.setVisible(False)
+        meta_layout.addWidget(self.meta_method_label)
+
+        self.meta_created_label = QLabel()
+        self.meta_created_label.setVisible(False)
+        small_font = QFont(); small_font.setPointSize(8)
+        self.meta_created_label.setFont(small_font)
+        meta_layout.addWidget(self.meta_created_label)
+
+        sep2 = QFrame(); sep2.setFrameShape(QFrame.Shape.VLine)
+        sep2.setFrameShadow(QFrame.Shadow.Sunken)
+        meta_layout.addWidget(sep2)
+
+        self.meta_tags_label = QLabel()
+        self.meta_tags_label.setVisible(False)
+        self.meta_tags_label.setFont(small_font)
+        meta_layout.addWidget(self.meta_tags_label)
+
+        self.meta_internal_tags_label = QLabel()
+        self.meta_internal_tags_label.setVisible(False)
+        self.meta_internal_tags_label.setFont(small_font)
+        meta_layout.addWidget(self.meta_internal_tags_label)
+
+        sep3 = QFrame(); sep3.setFrameShape(QFrame.Shape.VLine)
+        sep3.setFrameShadow(QFrame.Shadow.Sunken)
+        meta_layout.addWidget(sep3)
+
+        self.meta_note_label = QLabel()
+        self.meta_note_label.setVisible(False)
+        self.meta_note_label.setFont(small_font)
+        self.meta_note_label.setWordWrap(False)
+        meta_layout.addWidget(self.meta_note_label)
+
+        meta_layout.addStretch()
+
+        root_layout.addWidget(self.metadata_frame)
+
+    # ── SCANNER SLOTS ──────────────────────────────────────────────────────────
 
     def _on_scan(self):
-        """
-        Private slot to handle the returnPressed signal from the scanner input.
-        It emits the public barcode_scanned signal with the input text.
-        """
         text = self.scanner_input.text()
         self.scanner_input.clear()
         self.barcode_scanned.emit(text)
 
     def _on_sim_scan(self):
-        """
-        Private slot for the scan simulator panel (dev mode only).
-
-        Reads text from the visible simulator input field and emits
-        the same ``barcode_scanned`` signal as a physical scanner would,
-        so all normal packing logic handles it unchanged.
-        """
         text = self.sim_input.text().strip()
         if text:
             self.sim_input.clear()
             self.barcode_scanned.emit(text)
 
     def _on_manual_confirm(self, sku: str):
-        """
-        Private slot for the 'Confirm Manually' button. Emits the
-        barcode_scanned signal with the SKU for the corresponding row.
-
-        Args:
-            sku (str): The SKU of the item to confirm.
-        """
         if sku:
             self.barcode_scanned.emit(sku)
         self.set_focus_to_scanner()
+
+    def _on_force_complete(self, sku: str):
+        if sku:
+            self.force_complete_sku.emit(sku)
+        self.set_focus_to_scanner()
+
+    # ── SESSION PROGRESS ───────────────────────────────────────────────────────
+
+    def update_session_progress(self, completed: int, total: int):
+        """Updates the session-wide progress bar and label."""
+        self.session_progress_bar.setRange(0, max(total, 1))
+        self.session_progress_bar.setValue(completed)
+        self.session_progress_label.setText(f"{completed} of {total} completed")
+
+    # ── ORDER METADATA (BOTTOM STRIP) ─────────────────────────────────────────
+
+    def display_order_metadata(self, metadata: dict, courier: str = ''):
+        """Populates and shows the order metadata strip at the bottom."""
+        # Status badge
+        status = metadata.get('status', '')
+        if status:
+            bg, fg = STATUS_COLORS.get(status, DEFAULT_STATUS_COLOR)
+            self.meta_status_label.setText(status)
+            self.meta_status_label.setStyleSheet(
+                f"background-color: {bg}; color: {fg}; {_BADGE_STYLE}"
+            )
+            self.meta_status_label.setVisible(True)
+        else:
+            self.meta_status_label.setVisible(False)
+
+        # Courier badge
+        courier_name = courier or metadata.get('courier', '')
+        if courier_name:
+            bg, fg = COURIER_COLORS.get(courier_name, DEFAULT_COURIER_COLOR)
+            self.meta_courier_label.setText(courier_name)
+            self.meta_courier_label.setStyleSheet(
+                f"background-color: {bg}; color: {fg}; {_BADGE_STYLE}"
+            )
+            self.meta_courier_label.setVisible(True)
+        else:
+            self.meta_courier_label.setVisible(False)
+
+        # Recommended box
+        box = metadata.get('recommended_box', '')
+        if box:
+            self.meta_box_label.setText(f"📦 {box}")
+            self.meta_box_label.setVisible(True)
+        else:
+            self.meta_box_label.setVisible(False)
+
+        # Shipping method
+        method = metadata.get('shipping_method', '')
+        if method:
+            self.meta_method_label.setText(f"🚚 {method}")
+            self.meta_method_label.setVisible(True)
+        else:
+            self.meta_method_label.setVisible(False)
+
+        # Created at (date only)
+        created = metadata.get('created_at', '')
+        if created:
+            date_str = created[:10] if len(created) >= 10 else created
+            self.meta_created_label.setText(f"Created: {date_str}")
+            self.meta_created_label.setVisible(True)
+        else:
+            self.meta_created_label.setVisible(False)
+
+        # Tags
+        tags = metadata.get('tags', [])
+        if tags:
+            self.meta_tags_label.setText("Tags: " + ", ".join(str(t) for t in tags))
+            self.meta_tags_label.setVisible(True)
+        else:
+            self.meta_tags_label.setVisible(False)
+
+        # Internal tags
+        internal_tags = metadata.get('internal_tags', [])
+        if internal_tags:
+            self.meta_internal_tags_label.setText(
+                "⚙ " + ", ".join(str(t) for t in internal_tags)
+            )
+            self.meta_internal_tags_label.setVisible(True)
+        else:
+            self.meta_internal_tags_label.setVisible(False)
+
+        # System note
+        note = metadata.get('system_note', '')
+        if note:
+            # Truncate if too long for bottom strip
+            display_note = note[:80] + "…" if len(note) > 80 else note
+            self.meta_note_label.setText(f"⚠ {display_note}")
+            self.meta_note_label.setToolTip(note)
+            self.meta_note_label.setVisible(True)
+        else:
+            self.meta_note_label.setVisible(False)
+
+        self.metadata_frame.setVisible(True)
+
+    def clear_order_info(self):
+        """Hides the order metadata strip."""
+        self.metadata_frame.setVisible(False)
+
+    # ── ORDER SUMMARY TABLE (LEFT PANEL) ──────────────────────────────────────
+
+    def update_order_summary(self, items: List[Dict[str, Any]]):
+        """
+        Aggregates items by SKU and populates the 'Items to Pack' summary table.
+        Shows one row per unique SKU with total quantity.
+        """
+        aggregated: Dict[str, Dict] = {}
+        for item in items:
+            sku = item.get('SKU', '')
+            if not sku:
+                continue
+            if sku not in aggregated:
+                aggregated[sku] = {'product': item.get('Product_Name', ''), 'qty': 0}
+            try:
+                aggregated[sku]['qty'] += int(float(item.get('Quantity', 1)))
+            except (ValueError, TypeError):
+                aggregated[sku]['qty'] += 1
+
+        self.summary_table.setRowCount(len(aggregated))
+        for row, (sku, data) in enumerate(aggregated.items()):
+            qty = data['qty']
+            sku_item = QTableWidgetItem(sku)
+            prod_item = QTableWidgetItem(data['product'])
+            qty_item = QTableWidgetItem(str(qty))
+            qty_item.setTextAlignment(Qt.AlignCenter)
+            if qty > 1:
+                bold = QFont(); bold.setBold(True)
+                qty_item.setFont(bold)
+                qty_item.setForeground(QColor("#ffc107"))
+            self.summary_table.setItem(row, 0, sku_item)
+            self.summary_table.setItem(row, 1, prod_item)
+            self.summary_table.setItem(row, 2, qty_item)
+
+    # ── MAIN SKU TABLE ─────────────────────────────────────────────────────────
 
     def display_order(self, items: List[Dict[str, Any]], order_state: List[Dict[str, Any]]):
         """
         Populates the items table with the details of the current order.
 
-        It clears the table and then fills it with the products for the given
-        order. It also updates the display based on any existing progress
-        (e.g., if the order was partially packed in a previous session).
-
         Args:
-            items (List[Dict[str, Any]]): A list of dictionaries, where each
-                                          represents a product in the order.
-            order_state (List[Dict[str, Any]]): The current packing state for the
-                                                order, showing packed counts for each row.
+            items: List of item dicts (Order_Number, SKU, Product_Name, Quantity).
+            order_state: Current packing state per row.
         """
         self.table.setRowCount(len(items))
+        # Explicit accessible colors, independent of system palette
+        pending_bg = QColor("#1a3550")
+        pending_fg = QColor("#90caf9")
 
-        # First, populate the table with all items as 'Pending'
         for row, item in enumerate(items):
             sku = item.get('SKU', '')
-            quantity = str(item.get('Quantity', ''))
+            quantity_str = str(item.get('Quantity', '1'))
+            try:
+                quantity_int = int(float(quantity_str))
+            except (ValueError, TypeError):
+                quantity_int = 1
 
             self.table.setItem(row, 0, QTableWidgetItem(item.get('Product_Name', '')))
             self.table.setItem(row, 1, QTableWidgetItem(sku))
-            self.table.setItem(row, 2, QTableWidgetItem(f"0 / {quantity}")) # Default to 0 packed
+
+            qty_item = QTableWidgetItem(f"0 / {quantity_int}")
+            qty_item.setTextAlignment(Qt.AlignCenter)
+            if quantity_int > 1:
+                bold_font = qty_item.font(); bold_font.setBold(True)
+                qty_item.setFont(bold_font)
+                qty_item.setBackground(QColor("#5a4a00"))
+                qty_item.setForeground(QColor("#ffc107"))
+            self.table.setItem(row, 2, qty_item)
 
             status_item = QTableWidgetItem("Pending")
-            palette = self.table.palette()
-            pending_bg = palette.color(QPalette.ColorRole.Highlight).lighter(180)
-            pending_fg = palette.color(QPalette.ColorRole.HighlightedText)
             status_item.setBackground(pending_bg)
             status_item.setForeground(pending_fg)
             self.table.setItem(row, 3, status_item)
 
-            confirm_button = QPushButton("Confirm Manually")
-            confirm_button.setFocusPolicy(Qt.NoFocus)
-            confirm_button.clicked.connect(partial(self._on_manual_confirm, sku))
-            self.table.setCellWidget(row, 4, confirm_button)
+            confirm_btn = QPushButton("Confirm")
+            confirm_btn.setFocusPolicy(Qt.NoFocus)
+            confirm_btn.setObjectName("ConfirmBtn")
+            confirm_btn.clicked.connect(partial(self._on_manual_confirm, sku))
+            self.table.setCellWidget(row, 4, confirm_btn)
 
-        # Now, iterate through the state list and update rows that have progress
+            force_btn = QPushButton("Force")
+            force_btn.setFocusPolicy(Qt.NoFocus)
+            force_btn.setObjectName("ForceBtn")
+            force_btn.setToolTip("Force-complete this SKU (mark all units as packed)")
+            force_btn.clicked.connect(partial(self._on_force_complete, sku))
+            self.table.setCellWidget(row, 5, force_btn)
+
+        # Apply existing progress
+        first_unpacked_row = None
         for state_item in order_state:
             row_index = state_item.get('row')
             packed_count = state_item.get('packed', 0)
-
-            # Check if the row index is valid and if there's anything packed
             if row_index is not None and packed_count > 0 and row_index < self.table.rowCount():
                 required_count = state_item.get('required', 1)
                 is_complete = packed_count >= required_count
                 self.update_item_row(row_index, packed_count, is_complete)
+                if not is_complete and first_unpacked_row is None:
+                    first_unpacked_row = row_index
+            elif row_index is not None and first_unpacked_row is None:
+                first_unpacked_row = row_index
 
-        self.status_label.setText(f"Order {items[0]['Order_Number']}\nIn Progress...")
+        # Auto-scroll to first unpacked row when resuming
+        if first_unpacked_row is not None:
+            item_to_scroll = self.table.item(first_unpacked_row, 0)
+            if item_to_scroll:
+                self.table.scrollToItem(item_to_scroll, QAbstractItemView.ScrollHint.PositionAtTop)
+
+        self.update_order_summary(items)
+
+        order_number = items[0]['Order_Number'] if items else ''
+        self.status_label.setText(f"Order {order_number}\nIn Progress…")
+        self.skip_button.setEnabled(True)
         self.set_focus_to_scanner()
 
     def update_item_row(self, row: int, packed_count: int, is_complete: bool):
-        """
-        Updates a single row in the items table to reflect a new packed count.
-
-        Args:
-            row (int): The table row index to update.
-            packed_count (int): The new number of items packed for that SKU.
-            is_complete (bool): Whether this SKU is now fully packed.
-        """
-        # Check if table item exists before accessing
+        """Updates a single row to reflect a new packed count."""
+        if row < 0 or row >= self.table.rowCount():
+            logger.warning(f"update_item_row: row {row} out of bounds (table has {self.table.rowCount()} rows)")
+            return
         quantity_item = self.table.item(row, 2)
         if quantity_item is None:
             logger.warning(f"Cannot update row {row}: quantity item is None")
             return
 
         required_quantity = quantity_item.text().split(' / ')[1]
+        try:
+            required_int = int(required_quantity)
+        except ValueError:
+            required_int = 1
+
         quantity_item.setText(f"{packed_count} / {required_quantity}")
 
         if is_complete:
             status_item = QTableWidgetItem("Packed")
-            status_item.setBackground(QColor("#1e4d2b"))  # muted dark green
+            status_item.setBackground(QColor("#1e4d2b"))
             status_item.setForeground(QColor("#43a047"))
             self.table.setItem(row, 3, status_item)
-            self.table.cellWidget(row, 4).setEnabled(False)
+            confirm_btn = self.table.cellWidget(row, 4)
+            if confirm_btn:
+                confirm_btn.setEnabled(False)
+        else:
+            if required_int > 1:
+                bold_font = quantity_item.font(); bold_font.setBold(True)
+                quantity_item.setFont(bold_font)
+                quantity_item.setBackground(QColor("#5a4a00"))
+                quantity_item.setForeground(QColor("#ffc107"))
+
+    # ── NOTIFICATIONS ──────────────────────────────────────────────────────────
 
     def show_notification(self, text: str, color_name: str):
-        """
-        Displays a large, colored notification message.
-
-        Args:
-            text (str): The message to display.
-            color_name (str): The name of the color for the text (e.g., "red").
-        """
+        """Displays a large colored notification message."""
         self.notification_label.setText(text)
         self.notification_label.setStyleSheet(f"color: {color_name};")
 
+    # ── HISTORY ────────────────────────────────────────────────────────────────
+
+    def add_order_to_history(self, order_number: str, item_count: int = 0):
+        """Adds an order to the top of the scan history table."""
+        self.history_table.insertRow(0)
+        self.history_table.setItem(0, 0, QTableWidgetItem(str(order_number)))
+        count_item = QTableWidgetItem(str(item_count) if item_count else "")
+        count_item.setTextAlignment(Qt.AlignCenter)
+        self.history_table.setItem(0, 1, count_item)
+
+    def show_previous_order_items(self, items: List[Dict[str, Any]]):
+        """Shows items of the just-completed/skipped order in a dimmed reference table."""
+        dim_color = QColor("#555555")
+        self.prev_order_table.setRowCount(len(items))
+        for i, item in enumerate(items):
+            sku_cell = QTableWidgetItem(item.get('SKU', ''))
+            name_cell = QTableWidgetItem(item.get('Product_Name', ''))
+            sku_cell.setForeground(dim_color)
+            name_cell.setForeground(dim_color)
+            self.prev_order_table.setItem(i, 0, sku_cell)
+            self.prev_order_table.setItem(i, 1, name_cell)
+        self.prev_order_table.setVisible(True)
+
+    # ── SCREEN MANAGEMENT ─────────────────────────────────────────────────────
+
     def clear_screen(self):
-        """
-        Resets the widget to its initial state, ready for the next order.
-        """
+        """Resets the main table to initial state, ready for next order."""
         self.table.clearContents()
         self.table.setRowCount(0)
+        self.summary_table.clearContents()
+        self.summary_table.setRowCount(0)
         self.status_label.setText("Scan the next order's barcode")
         self.notification_label.setText("")
         self.scanner_input.clear()
         self.scanner_input.setEnabled(True)
+        self.skip_button.setEnabled(False)
+        self.clear_order_info()
         self.set_focus_to_scanner()
 
     def set_focus_to_scanner(self):
-        """
-        Sets the keyboard focus to the hidden scanner input field.
-        This is crucial for ensuring the barcode scanner's output is captured.
-        """
+        """Sets keyboard focus to the hidden scanner input field."""
         self.scanner_input.setFocus()
 
     def update_raw_scan_display(self, text: str):
-        """
-        Updates the label that shows the raw text from the last scan.
-
-        Args:
-            text (str): The text captured from the scanner.
-        """
+        """Updates the raw scan display label."""
         self.raw_scan_label.setText(text)
 
-    def add_order_to_history(self, order_number: str):
-        """
-        Adds an order number to the top of the scan history table.
-
-        Args:
-            order_number (str): The order number that was just scanned.
-        """
-        self.history_table.insertRow(0)
-        self.history_table.setItem(0, 0, QTableWidgetItem(str(order_number)))
+    def enable_skip_button(self, enabled: bool):
+        """Enables or disables the Skip Order button."""
+        self.skip_button.setEnabled(enabled)

--- a/src/packer_mode_widget.py
+++ b/src/packer_mode_widget.py
@@ -305,6 +305,14 @@ class PackerModeWidget(QWidget):
         self.meta_courier_label.setVisible(False)
         meta_layout.addWidget(self.meta_courier_label)
 
+        self.meta_destination_label = QLabel()
+        self.meta_destination_label.setVisible(False)
+        meta_layout.addWidget(self.meta_destination_label)
+
+        self.meta_order_type_label = QLabel()
+        self.meta_order_type_label.setVisible(False)
+        meta_layout.addWidget(self.meta_order_type_label)
+
         sep1 = QFrame(); sep1.setFrameShape(QFrame.Shape.VLine)
         sep1.setFrameShadow(QFrame.Shadow.Sunken)
         meta_layout.addWidget(sep1)
@@ -415,6 +423,30 @@ class PackerModeWidget(QWidget):
             self.meta_courier_label.setVisible(True)
         else:
             self.meta_courier_label.setVisible(False)
+
+        # Destination (country)
+        destination = metadata.get('destination', '')
+        if destination:
+            self.meta_destination_label.setText(destination)
+            self.meta_destination_label.setStyleSheet(
+                f"background-color: #37474f; color: #b0bec5; {_BADGE_STYLE}"
+            )
+            self.meta_destination_label.setVisible(True)
+        else:
+            self.meta_destination_label.setVisible(False)
+
+        # Order type (Single/Multi)
+        order_type = metadata.get('order_type', '')
+        if order_type:
+            ot_bg = "#4a148c" if order_type == "Multi" else "#1b5e20"
+            ot_fg = "#ce93d8" if order_type == "Multi" else "#81c784"
+            self.meta_order_type_label.setText(order_type)
+            self.meta_order_type_label.setStyleSheet(
+                f"background-color: {ot_bg}; color: {ot_fg}; {_BADGE_STYLE}"
+            )
+            self.meta_order_type_label.setVisible(True)
+        else:
+            self.meta_order_type_label.setVisible(False)
 
         # Recommended box
         box = metadata.get('recommended_box', '')

--- a/src/packer_mode_widget.py
+++ b/src/packer_mode_widget.py
@@ -347,6 +347,12 @@ class PackerModeWidget(QWidget):
         self.meta_note_label.setWordWrap(False)
         meta_layout.addWidget(self.meta_note_label)
 
+        self.meta_status_note_label = QLabel()
+        self.meta_status_note_label.setVisible(False)
+        self.meta_status_note_label.setFont(small_font)
+        self.meta_status_note_label.setWordWrap(False)
+        meta_layout.addWidget(self.meta_status_note_label)
+
         meta_layout.addStretch()
 
         root_layout.addWidget(self.metadata_frame)
@@ -463,6 +469,16 @@ class PackerModeWidget(QWidget):
             self.meta_note_label.setVisible(True)
         else:
             self.meta_note_label.setVisible(False)
+
+        # Status note
+        status_note = metadata.get('status_note', '')
+        if status_note:
+            display_sn = status_note[:80] + "…" if len(status_note) > 80 else status_note
+            self.meta_status_note_label.setText(f"📋 {display_sn}")
+            self.meta_status_note_label.setToolTip(status_note)
+            self.meta_status_note_label.setVisible(True)
+        else:
+            self.meta_status_note_label.setVisible(False)
 
         self.metadata_frame.setVisible(True)
 

--- a/tests/test_gui_navigation.py
+++ b/tests/test_gui_navigation.py
@@ -105,6 +105,7 @@ Environment = test
             # (We'll mock the logic to avoid file operations)
             window.logic = Mock()
             window.logic.orders_data = {'ORDER1': {}}
+            window.logic.session_packing_state = {'completed_orders': [], 'skipped_orders': []}
             window.logic.clear_current_order = Mock()
 
             # Switch to Packer Mode

--- a/tests/test_packer_logic.py
+++ b/tests/test_packer_logic.py
@@ -515,9 +515,8 @@ def _load_json_with_metadata(packer_logic, test_dir):
                 "tags": ["summer-2026"],
                 "created_at": "2026-01-10T09:00:00",
                 "recommended_box": "Box_Small",
-                "shipping_method": "express",
+                "shopify_status": "unfulfilled",
                 "destination": "BG",
-                "order_type": "Multi",
                 "items": [
                     {"sku": "SKU-M", "quantity": 1, "product_name": "Meta Widget"}
                 ]
@@ -580,10 +579,10 @@ def test_get_order_metadata_destination(packer_logic, test_dir):
     assert metadata['destination'] == 'BG'
 
 
-def test_get_order_metadata_order_type(packer_logic, test_dir):
+def test_get_order_metadata_shopify_status(packer_logic, test_dir):
     _load_json_with_metadata(packer_logic, test_dir)
     metadata = packer_logic.get_order_metadata("ORD-META")
-    assert metadata['order_type'] == 'Multi'
+    assert metadata['shopify_status'] == 'unfulfilled'
 
 
 def test_get_order_metadata_created_at(packer_logic, test_dir):
@@ -629,9 +628,9 @@ def test_get_order_metadata_missing_optional_fields_default_empty(packer_logic, 
     assert metadata['internal_tags'] == []
     assert metadata['tags'] == []
     assert metadata['status'] == ''
+    assert metadata['shopify_status'] == ''
     assert metadata['recommended_box'] == ''
     assert metadata['destination'] == ''
-    assert metadata['order_type'] == ''
 
 
 def test_get_order_metadata_nan_tags_filtered(packer_logic, test_dir):

--- a/tests/test_packer_logic.py
+++ b/tests/test_packer_logic.py
@@ -510,6 +510,7 @@ def _load_json_with_metadata(packer_logic, test_dir):
                 "courier": "Speedy",
                 "status": "Fulfillable",
                 "system_note": "Fragile items inside",
+                "status_note": "VIP — expedite",
                 "internal_tags": ["priority", "vip"],
                 "tags": ["summer-2026"],
                 "created_at": "2026-01-10T09:00:00",
@@ -544,6 +545,12 @@ def test_get_order_metadata_system_note(packer_logic, test_dir):
     _load_json_with_metadata(packer_logic, test_dir)
     metadata = packer_logic.get_order_metadata("ORD-META")
     assert metadata['system_note'] == 'Fragile items inside'
+
+
+def test_get_order_metadata_status_note(packer_logic, test_dir):
+    _load_json_with_metadata(packer_logic, test_dir)
+    metadata = packer_logic.get_order_metadata("ORD-META")
+    assert metadata['status_note'] == 'VIP — expedite'
 
 
 def test_get_order_metadata_internal_tags(packer_logic, test_dir):

--- a/tests/test_packer_logic.py
+++ b/tests/test_packer_logic.py
@@ -235,20 +235,17 @@ def test_load_packing_list_json_missing_file(packer_logic, test_dir):
 
 
 def test_load_packing_list_json_missing_required_fields(packer_logic, test_dir):
-    """Test loading JSON with missing required fields."""
+    """Missing order_number is the only hard-required field; raises ValueError."""
     import json
     from pathlib import Path
 
-    # Create JSON with missing courier field
     packing_list_data = {
         "list_name": "Invalid_List",
         "orders": [
             {
-                "order_number": "ORDER-001",
-                # Missing courier field
-                "items": [
-                    {"sku": "SKU-123", "quantity": 1, "product_name": "Product A"}
-                ]
+                # Missing order_number — only field that causes a hard error
+                "courier": "DHL",
+                "items": [{"sku": "SKU-123", "quantity": 1, "product_name": "Product A"}]
             }
         ]
     }
@@ -257,9 +254,33 @@ def test_load_packing_list_json_missing_required_fields(packer_logic, test_dir):
     with open(json_path, 'w', encoding='utf-8') as f:
         json.dump(packing_list_data, f)
 
-    # Should raise ValueError for missing required fields
-    with pytest.raises(ValueError, match="Missing required fields in order data"):
+    with pytest.raises(ValueError, match="Missing required field 'order_number'"):
         packer_logic.load_packing_list_json(json_path)
+
+
+def test_load_packing_list_json_missing_courier_defaults(packer_logic, test_dir):
+    """Missing courier field should be tolerated and default to 'N/A'."""
+    import json
+    from pathlib import Path
+
+    packing_list_data = {
+        "list_name": "NoCourier_List",
+        "orders": [
+            {
+                "order_number": "ORDER-NC1",
+                "items": [{"sku": "SKU-X", "quantity": 1, "product_name": "Product X"}]
+            }
+        ]
+    }
+
+    json_path = Path(test_dir) / "no_courier.json"
+    with open(json_path, 'w', encoding='utf-8') as f:
+        json.dump(packing_list_data, f)
+
+    count, _ = packer_logic.load_packing_list_json(json_path)
+    assert count == 1
+    meta = packer_logic.get_order_metadata("ORDER-NC1")
+    assert meta['courier'] == 'N/A'
 
 
 def test_load_packing_list_json_empty_orders(packer_logic, test_dir):
@@ -374,3 +395,231 @@ def test_packing_workflow_with_json_list(packer_logic, test_dir):
 
     # Verify order completed
     assert 'ORD-100' in packer_logic.session_packing_state['completed_orders']
+
+
+# ============================================================================
+# skip_order Tests
+# ============================================================================
+
+def _make_loaded_logic(packer_logic, test_dir):
+    """Helper: load a packing list and start packing ORD-SKIP."""
+    import json
+    from pathlib import Path
+    packing_list_data = {
+        "list_name": "Skip_Test",
+        "total_orders": 2,
+        "orders": [
+            {
+                "order_number": "ORD-SKIP",
+                "courier": "DHL",
+                "items": [
+                    {"sku": "SKU-1", "quantity": 2, "product_name": "Widget 1"}
+                ]
+            },
+            {
+                "order_number": "ORD-OTHER",
+                "courier": "DHL",
+                "items": [
+                    {"sku": "SKU-2", "quantity": 1, "product_name": "Widget 2"}
+                ]
+            }
+        ]
+    }
+    json_path = Path(test_dir) / "skip_test.json"
+    with open(json_path, 'w', encoding='utf-8') as f:
+        json.dump(packing_list_data, f)
+    packer_logic.load_packing_list_json(json_path)
+    items, status = packer_logic.start_order_packing('ORD-SKIP')
+    assert status == "ORDER_LOADED"
+    return items
+
+
+def test_skip_order_clears_current_order(packer_logic, test_dir):
+    """skip_order() should clear the active order."""
+    _make_loaded_logic(packer_logic, test_dir)
+    assert packer_logic.current_order_number == "ORD-SKIP"
+    packer_logic.skip_order()
+    assert packer_logic.current_order_number is None
+
+
+def test_skip_order_returns_true(packer_logic, test_dir):
+    """skip_order() should return True when an order is active."""
+    _make_loaded_logic(packer_logic, test_dir)
+    result = packer_logic.skip_order()
+    assert result is True
+
+
+def test_skip_order_returns_false_when_no_order(packer_logic):
+    """skip_order() returns False when no order is active."""
+    result = packer_logic.skip_order()
+    assert result is False
+
+
+def test_skip_order_adds_to_skipped_orders(packer_logic, test_dir):
+    """skip_order() adds the order to skipped_orders list."""
+    _make_loaded_logic(packer_logic, test_dir)
+    packer_logic.skip_order()
+    assert "ORD-SKIP" in packer_logic.session_packing_state.get('skipped_orders', [])
+
+
+def test_skip_order_preserves_in_progress_state(packer_logic, test_dir):
+    """skip_order() must NOT remove the order from in_progress (resume support)."""
+    _make_loaded_logic(packer_logic, test_dir)
+    # Pack 1 unit before skipping
+    packer_logic.process_sku_scan('SKU-1')
+    packer_logic.skip_order()
+    # in_progress state should still contain ORD-SKIP
+    assert "ORD-SKIP" in packer_logic.session_packing_state.get('in_progress', {})
+
+
+def test_skip_order_does_not_mark_as_completed(packer_logic, test_dir):
+    """A skipped order should not appear in completed_orders."""
+    _make_loaded_logic(packer_logic, test_dir)
+    packer_logic.skip_order()
+    assert "ORD-SKIP" not in packer_logic.session_packing_state.get('completed_orders', [])
+
+
+def test_skipped_order_can_be_resumed(packer_logic, test_dir):
+    """After skipping, scanning the order barcode again should resume it."""
+    _make_loaded_logic(packer_logic, test_dir)
+    packer_logic.skip_order()
+    assert packer_logic.current_order_number is None
+
+    # Re-scan to resume
+    items, status = packer_logic.start_order_packing('ORD-SKIP')
+    assert status == "ORDER_LOADED"
+    assert packer_logic.current_order_number == "ORD-SKIP"
+    # Order should no longer be in skipped_orders
+    assert "ORD-SKIP" not in packer_logic.session_packing_state.get('skipped_orders', [])
+
+
+# ============================================================================
+# get_order_metadata Tests
+# ============================================================================
+
+def _load_json_with_metadata(packer_logic, test_dir):
+    """Helper: load a packing list JSON that includes Shopify metadata fields."""
+    import json
+    from pathlib import Path
+    packing_list_data = {
+        "list_name": "Meta_Test",
+        "total_orders": 1,
+        "orders": [
+            {
+                "order_number": "ORD-META",
+                "courier": "Speedy",
+                "status": "Fulfillable",
+                "system_note": "Fragile items inside",
+                "internal_tags": ["priority", "vip"],
+                "tags": ["summer-2026"],
+                "created_at": "2026-01-10T09:00:00",
+                "recommended_box": "Box_Small",
+                "shipping_method": "express",
+                "items": [
+                    {"sku": "SKU-M", "quantity": 1, "product_name": "Meta Widget"}
+                ]
+            }
+        ]
+    }
+    json_path = Path(test_dir) / "meta_test.json"
+    with open(json_path, 'w', encoding='utf-8') as f:
+        json.dump(packing_list_data, f)
+    packer_logic.load_packing_list_json(json_path)
+
+
+def test_get_order_metadata_returns_dict(packer_logic, test_dir):
+    """get_order_metadata() returns a dict for a loaded order."""
+    _load_json_with_metadata(packer_logic, test_dir)
+    metadata = packer_logic.get_order_metadata("ORD-META")
+    assert isinstance(metadata, dict)
+
+
+def test_get_order_metadata_status_field(packer_logic, test_dir):
+    _load_json_with_metadata(packer_logic, test_dir)
+    metadata = packer_logic.get_order_metadata("ORD-META")
+    assert metadata['status'] == 'Fulfillable'
+
+
+def test_get_order_metadata_system_note(packer_logic, test_dir):
+    _load_json_with_metadata(packer_logic, test_dir)
+    metadata = packer_logic.get_order_metadata("ORD-META")
+    assert metadata['system_note'] == 'Fragile items inside'
+
+
+def test_get_order_metadata_internal_tags(packer_logic, test_dir):
+    _load_json_with_metadata(packer_logic, test_dir)
+    metadata = packer_logic.get_order_metadata("ORD-META")
+    assert 'priority' in metadata['internal_tags']
+    assert 'vip' in metadata['internal_tags']
+
+
+def test_get_order_metadata_tags(packer_logic, test_dir):
+    _load_json_with_metadata(packer_logic, test_dir)
+    metadata = packer_logic.get_order_metadata("ORD-META")
+    assert 'summer-2026' in metadata['tags']
+
+
+def test_get_order_metadata_recommended_box(packer_logic, test_dir):
+    _load_json_with_metadata(packer_logic, test_dir)
+    metadata = packer_logic.get_order_metadata("ORD-META")
+    assert metadata['recommended_box'] == 'Box_Small'
+
+
+def test_get_order_metadata_created_at(packer_logic, test_dir):
+    _load_json_with_metadata(packer_logic, test_dir)
+    metadata = packer_logic.get_order_metadata("ORD-META")
+    assert '2026-01-10' in metadata['created_at']
+
+
+def test_get_order_metadata_courier(packer_logic, test_dir):
+    _load_json_with_metadata(packer_logic, test_dir)
+    metadata = packer_logic.get_order_metadata("ORD-META")
+    assert metadata['courier'] == 'Speedy'
+
+
+def test_get_order_metadata_unknown_order_returns_empty(packer_logic, test_dir):
+    """get_order_metadata() returns {} for an order that doesn't exist."""
+    _load_json_with_metadata(packer_logic, test_dir)
+    metadata = packer_logic.get_order_metadata("NONEXISTENT")
+    assert metadata == {}
+
+
+def test_get_order_metadata_missing_optional_fields_default_empty(packer_logic, test_dir):
+    """Orders without optional metadata fields return empty strings/lists."""
+    import json
+    from pathlib import Path
+    minimal_data = {
+        "list_name": "Minimal",
+        "total_orders": 1,
+        "orders": [
+            {
+                "order_number": "ORD-MIN",
+                "courier": "DHL",
+                "items": [{"sku": "SKU-Z", "quantity": 1, "product_name": "Z Widget"}]
+            }
+        ]
+    }
+    json_path = Path(test_dir) / "minimal.json"
+    with open(json_path, 'w', encoding='utf-8') as f:
+        json.dump(minimal_data, f)
+    packer_logic.load_packing_list_json(json_path)
+    metadata = packer_logic.get_order_metadata("ORD-MIN")
+    assert metadata['system_note'] == ''
+    assert metadata['internal_tags'] == []
+    assert metadata['tags'] == []
+    assert metadata['status'] == ''
+    assert metadata['recommended_box'] == ''
+
+
+# ============================================================================
+# skipped_orders persistence
+# ============================================================================
+
+def test_skipped_orders_initialized_in_session_state(packer_logic):
+    """session_packing_state should always have 'skipped_orders' key."""
+    assert 'skipped_orders' in packer_logic.session_packing_state
+
+
+def test_skipped_orders_not_in_skipped_initially(packer_logic):
+    """Initially skipped_orders should be empty."""
+    assert packer_logic.session_packing_state['skipped_orders'] == []

--- a/tests/test_packer_mode_widget.py
+++ b/tests/test_packer_mode_widget.py
@@ -51,6 +51,7 @@ PARTIAL_STATE = [
 
 SAMPLE_METADATA = {
     'system_note': 'Handle with care',
+    'status_note': 'VIP customer — expedite',
     'internal_tags': ['priority', 'fragile'],
     'tags': ['summer-sale'],
     'created_at': '2026-01-15T10:00:00',
@@ -476,6 +477,19 @@ class TestDisplayOrderMetadata:
         qtbot.addWidget(widget)
         widget.display_order_metadata(SAMPLE_METADATA)
         assert "Handle with care" in widget.meta_note_label.text()
+
+    def test_status_note_shown(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata(SAMPLE_METADATA)
+        assert "VIP customer" in widget.meta_status_note_label.text()
+        assert not widget.meta_status_note_label.isHidden()
+
+    def test_empty_status_note_hidden(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata({'status_note': ''})
+        assert widget.meta_status_note_label.isHidden()
 
     def test_empty_metadata_does_not_crash(self, qtbot):
         widget = PackerModeWidget()

--- a/tests/test_packer_mode_widget.py
+++ b/tests/test_packer_mode_widget.py
@@ -58,6 +58,8 @@ SAMPLE_METADATA = {
     'status': 'Fulfillable',
     'recommended_box': 'Box_Large',
     'shipping_method': 'express',
+    'destination': 'BG',
+    'order_type': 'Multi',
 }
 
 
@@ -490,6 +492,26 @@ class TestDisplayOrderMetadata:
         qtbot.addWidget(widget)
         widget.display_order_metadata({'status_note': ''})
         assert widget.meta_status_note_label.isHidden()
+
+    def test_destination_shown(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata(SAMPLE_METADATA)
+        assert "BG" in widget.meta_destination_label.text()
+        assert not widget.meta_destination_label.isHidden()
+
+    def test_order_type_shown(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata(SAMPLE_METADATA)
+        assert "Multi" in widget.meta_order_type_label.text()
+        assert not widget.meta_order_type_label.isHidden()
+
+    def test_empty_destination_hidden(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata({'destination': ''})
+        assert widget.meta_destination_label.isHidden()
 
     def test_empty_metadata_does_not_crash(self, qtbot):
         widget = PackerModeWidget()

--- a/tests/test_packer_mode_widget.py
+++ b/tests/test_packer_mode_widget.py
@@ -5,18 +5,26 @@ Requires: pytest-qt (qtbot fixture from conftest via pytest-qt plugin).
 
 Tests cover:
 - Widget initialization (UI elements created)
-- display_order() — table populated, status label updated
+- display_order() — table populated, status label updated, qty highlighting
 - update_item_row() — quantity and status column updated
 - show_notification() — label text and style set
 - clear_screen() — table cleared, status/notification reset
 - update_raw_scan_display() — raw scan label updated
-- add_order_to_history() — row inserted at top of history table
+- add_order_to_history() — row inserted at top of history table (2 columns)
 - _on_scan() / barcode_scanned signal emitted
 - _on_manual_confirm() / barcode_scanned signal emitted from button
+- skip_order_requested signal
+- force_complete_sku signal
+- update_session_progress() — progress bar updated
+- display_order_metadata() — left panel populated
+- update_order_summary() — summary table populated with aggregated SKUs
+- show_previous_order_items() — dimmed previous order table populated
+- clear_order_info() — hides metadata/summary sections
 """
 
 import pytest
 from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor
 
 from packer_mode_widget import PackerModeWidget
 
@@ -30,11 +38,26 @@ SAMPLE_ITEMS = [
     {"Order_Number": "ORD-001", "SKU": "SKU-B", "Product_Name": "Product Beta", "Quantity": 1},
 ]
 
+MULTI_QTY_ITEMS = [
+    {"Order_Number": "ORD-002", "SKU": "SKU-X", "Product_Name": "Widget X", "Quantity": 5},
+    {"Order_Number": "ORD-002", "SKU": "SKU-Y", "Product_Name": "Widget Y", "Quantity": 1},
+]
+
 EMPTY_STATE = []
 
 PARTIAL_STATE = [
     {"row": 0, "packed": 1, "required": 2},
 ]
+
+SAMPLE_METADATA = {
+    'system_note': 'Handle with care',
+    'internal_tags': ['priority', 'fragile'],
+    'tags': ['summer-sale'],
+    'created_at': '2026-01-15T10:00:00',
+    'status': 'Fulfillable',
+    'recommended_box': 'Box_Large',
+    'shipping_method': 'express',
+}
 
 
 # ============================================================================
@@ -47,15 +70,15 @@ class TestPackerModeWidgetInit:
         qtbot.addWidget(widget)
         assert widget is not None
 
-    def test_table_has_five_columns(self, qtbot):
+    def test_table_has_six_columns(self, qtbot):
         widget = PackerModeWidget()
         qtbot.addWidget(widget)
-        assert widget.table.columnCount() == 5
+        assert widget.table.columnCount() == 6
 
-    def test_history_table_has_one_column(self, qtbot):
+    def test_history_table_has_two_columns(self, qtbot):
         widget = PackerModeWidget()
         qtbot.addWidget(widget)
-        assert widget.history_table.columnCount() == 1
+        assert widget.history_table.columnCount() == 2
 
     def test_status_label_initial_text(self, qtbot):
         widget = PackerModeWidget()
@@ -78,6 +101,31 @@ class TestPackerModeWidgetInit:
         qtbot.addWidget(widget)
         assert widget.scanner_input.width() == 1
         assert widget.scanner_input.height() == 1
+
+    def test_skip_button_initially_disabled(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        assert not widget.skip_button.isEnabled()
+
+    def test_metadata_frame_initially_hidden(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        assert widget.metadata_frame.isHidden()
+
+    def test_summary_table_initially_empty(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        assert widget.summary_table.rowCount() == 0
+
+    def test_prev_order_table_initially_hidden(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        assert widget.prev_order_table.isHidden()
+
+    def test_session_progress_bar_exists(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        assert widget.session_progress_bar is not None
 
 
 # ============================================================================
@@ -126,17 +174,52 @@ class TestDisplayOrder:
         widget = PackerModeWidget()
         qtbot.addWidget(widget)
         widget.display_order(SAMPLE_ITEMS, PARTIAL_STATE)
-        # Row 0 has 1 packed out of 2, so it's NOT complete — status stays Pending
         qty_text = widget.table.item(0, 2).text()
         assert qty_text == "1 / 2"
 
-    def test_confirm_button_in_action_column(self, qtbot):
+    def test_confirm_button_in_column_4(self, qtbot):
         widget = PackerModeWidget()
         qtbot.addWidget(widget)
         widget.display_order(SAMPLE_ITEMS, EMPTY_STATE)
         btn = widget.table.cellWidget(0, 4)
         assert btn is not None
-        assert btn.text() == "Confirm Manually"
+        assert "Confirm" in btn.text()
+
+    def test_force_button_in_column_5(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order(SAMPLE_ITEMS, EMPTY_STATE)
+        btn = widget.table.cellWidget(0, 5)
+        assert btn is not None
+        assert "Force" in btn.text()
+
+    def test_skip_button_enabled_after_display_order(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order(SAMPLE_ITEMS, EMPTY_STATE)
+        assert widget.skip_button.isEnabled()
+
+    def test_summary_table_populated_after_display_order(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order(SAMPLE_ITEMS, EMPTY_STATE)
+        assert widget.summary_table.rowCount() > 0
+
+    def test_qty_gt1_has_bold_font(self, qtbot):
+        """Items with quantity > 1 should have bold font in the qty cell."""
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order(MULTI_QTY_ITEMS, EMPTY_STATE)
+        qty_item = widget.table.item(0, 2)  # SKU-X, qty=5
+        assert qty_item.font().bold()
+
+    def test_qty_eq1_not_bold(self, qtbot):
+        """Items with quantity == 1 should not have bold font in qty cell."""
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order(MULTI_QTY_ITEMS, EMPTY_STATE)
+        qty_item = widget.table.item(1, 2)  # SKU-Y, qty=1
+        assert not qty_item.font().bold()
 
 
 # ============================================================================
@@ -166,11 +249,19 @@ class TestUpdateItemRow:
         btn = widget.table.cellWidget(0, 4)
         assert not btn.isEnabled()
 
+    def test_force_button_stays_enabled_when_complete(self, qtbot):
+        """Force button stays enabled even after row is complete (allows undo-style re-force)."""
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order(SAMPLE_ITEMS, EMPTY_STATE)
+        widget.update_item_row(0, 2, True)
+        btn = widget.table.cellWidget(0, 5)
+        assert btn.isEnabled()
+
     def test_invalid_row_does_not_raise(self, qtbot):
         """Calling update_item_row for a row that doesn't exist should not crash."""
         widget = PackerModeWidget()
         qtbot.addWidget(widget)
-        # No display_order called — table is empty
         widget.update_item_row(99, 1, False)  # Should log warning, not raise
 
 
@@ -223,8 +314,29 @@ class TestClearScreen:
         qtbot.addWidget(widget)
         widget.display_order(SAMPLE_ITEMS, EMPTY_STATE)
         widget.clear_screen()
-        # Should say something about next order or scan, not the previous order
         assert "ORD-001" not in widget.status_label.text()
+
+    def test_skip_button_disabled_after_clear(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order(SAMPLE_ITEMS, EMPTY_STATE)
+        assert widget.skip_button.isEnabled()
+        widget.clear_screen()
+        assert not widget.skip_button.isEnabled()
+
+    def test_metadata_frame_hidden_after_clear(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata(SAMPLE_METADATA, 'DHL')
+        widget.clear_screen()
+        assert widget.metadata_frame.isHidden()
+
+    def test_summary_table_cleared_after_clear(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order(SAMPLE_ITEMS, EMPTY_STATE)
+        widget.clear_screen()
+        assert widget.summary_table.rowCount() == 0
 
 
 # ============================================================================
@@ -271,6 +383,204 @@ class TestAddOrderToHistory:
             widget.add_order_to_history(f"ORD-{i:03d}")
         assert widget.history_table.rowCount() == 5
 
+    def test_item_count_in_second_column(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.add_order_to_history("ORD-001", item_count=3)
+        assert widget.history_table.item(0, 1).text() == "3"
+
+    def test_item_count_zero_shows_empty(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.add_order_to_history("ORD-001", item_count=0)
+        # item_count=0 shows empty string per implementation
+        text = widget.history_table.item(0, 1).text()
+        assert text == ""
+
+
+# ============================================================================
+# Session progress
+# ============================================================================
+
+class TestSessionProgress:
+    def test_update_session_progress_sets_value(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.update_session_progress(3, 10)
+        assert widget.session_progress_bar.value() == 3
+        assert widget.session_progress_bar.maximum() == 10
+
+    def test_update_session_progress_label(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.update_session_progress(5, 20)
+        assert "5" in widget.session_progress_label.text()
+        assert "20" in widget.session_progress_label.text()
+
+    def test_zero_total_does_not_crash(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.update_session_progress(0, 0)  # Should not raise (max=max(0,1)=1)
+
+
+# ============================================================================
+# Order metadata (left panel)
+# ============================================================================
+
+class TestDisplayOrderMetadata:
+    def test_metadata_frame_becomes_visible(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata(SAMPLE_METADATA)
+        assert not widget.metadata_frame.isHidden()
+
+    def test_status_label_populated(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata(SAMPLE_METADATA)
+        assert "Fulfillable" in widget.meta_status_label.text()
+
+    def test_courier_badge_populated(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata(SAMPLE_METADATA, courier='DHL')
+        assert "DHL" in widget.meta_courier_label.text()
+        assert not widget.meta_courier_label.isHidden()
+
+    def test_recommended_box_shown(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata(SAMPLE_METADATA)
+        assert "Box_Large" in widget.meta_box_label.text()
+
+    def test_created_date_shown(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata(SAMPLE_METADATA)
+        assert "2026-01-15" in widget.meta_created_label.text()
+
+    def test_tags_shown(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata(SAMPLE_METADATA)
+        assert "summer-sale" in widget.meta_tags_label.text()
+
+    def test_internal_tags_shown(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata(SAMPLE_METADATA)
+        assert "priority" in widget.meta_internal_tags_label.text()
+
+    def test_system_note_shown(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata(SAMPLE_METADATA)
+        assert "Handle with care" in widget.meta_note_label.text()
+
+    def test_empty_metadata_does_not_crash(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata({})  # Should not raise
+
+    def test_missing_status_hides_status_label(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata({'system_note': 'hi'})
+        assert widget.meta_status_label.isHidden()
+
+
+# ============================================================================
+# Order summary (aggregated items)
+# ============================================================================
+
+class TestUpdateOrderSummary:
+    def test_summary_table_populated_after_update(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.update_order_summary(SAMPLE_ITEMS)
+        assert widget.summary_table.rowCount() > 0
+
+    def test_unique_skus_in_summary(self, qtbot):
+        """Duplicate SKU rows should be aggregated into one summary row."""
+        items_with_dup = [
+            {"SKU": "SKU-A", "Product_Name": "Alpha", "Quantity": 2},
+            {"SKU": "SKU-A", "Product_Name": "Alpha", "Quantity": 1},
+            {"SKU": "SKU-B", "Product_Name": "Beta", "Quantity": 1},
+        ]
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.update_order_summary(items_with_dup)
+        assert widget.summary_table.rowCount() == 2  # SKU-A + SKU-B
+
+    def test_aggregated_qty_correct(self, qtbot):
+        """Duplicate SKU quantities should be summed."""
+        items_with_dup = [
+            {"SKU": "SKU-A", "Product_Name": "Alpha", "Quantity": 2},
+            {"SKU": "SKU-A", "Product_Name": "Alpha", "Quantity": 3},
+        ]
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.update_order_summary(items_with_dup)
+        assert widget.summary_table.rowCount() == 1
+        assert widget.summary_table.item(0, 2).text() == "5"
+
+    def test_empty_items_does_not_crash(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.update_order_summary([])  # Should not raise
+
+
+# ============================================================================
+# Previous order items (dimmed history)
+# ============================================================================
+
+class TestShowPreviousOrderItems:
+    def test_prev_table_becomes_visible(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.show_previous_order_items(SAMPLE_ITEMS)
+        assert not widget.prev_order_table.isHidden()
+
+    def test_prev_table_row_count(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.show_previous_order_items(SAMPLE_ITEMS)
+        assert widget.prev_order_table.rowCount() == len(SAMPLE_ITEMS)
+
+    def test_prev_table_sku_populated(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.show_previous_order_items(SAMPLE_ITEMS)
+        assert widget.prev_order_table.item(0, 0).text() == "SKU-A"
+
+    def test_empty_items_does_not_crash(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.show_previous_order_items([])  # Should not raise
+
+
+# ============================================================================
+# clear_order_info
+# ============================================================================
+
+class TestClearOrderInfo:
+    def test_hides_metadata_frame(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata(SAMPLE_METADATA)
+        assert not widget.metadata_frame.isHidden()
+        widget.clear_order_info()
+        assert widget.metadata_frame.isHidden()
+
+    def test_hides_metadata_frame_via_clear_order_info(self, qtbot):
+        """clear_order_info() hides metadata frame; summary table is cleared separately by clear_screen."""
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order_metadata(SAMPLE_METADATA)
+        assert not widget.metadata_frame.isHidden()
+        widget.clear_order_info()
+        assert widget.metadata_frame.isHidden()
+
 
 # ============================================================================
 # barcode_scanned signal
@@ -307,6 +617,56 @@ class TestBarcodeScanSignal:
         widget.barcode_scanned.connect(received.append)
 
         btn = widget.table.cellWidget(0, 4)
+        btn.click()
+
+        assert received == ["SKU-A"]
+
+
+# ============================================================================
+# skip_order_requested signal
+# ============================================================================
+
+class TestSkipOrderSignal:
+    def test_skip_button_emits_signal(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order(SAMPLE_ITEMS, EMPTY_STATE)  # enables skip button
+
+        received = []
+        widget.skip_order_requested.connect(lambda: received.append(True))
+
+        widget.skip_button.click()
+
+        assert received == [True]
+
+    def test_skip_button_disabled_does_not_emit(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        # Skip button is disabled initially — clicking it should not emit
+
+        received = []
+        widget.skip_order_requested.connect(lambda: received.append(True))
+
+        # Programmatically click when disabled — Qt won't emit for disabled buttons
+        widget.skip_button.click()
+
+        assert received == []
+
+
+# ============================================================================
+# force_complete_sku signal
+# ============================================================================
+
+class TestForceCompleteSkuSignal:
+    def test_force_button_emits_signal(self, qtbot):
+        widget = PackerModeWidget()
+        qtbot.addWidget(widget)
+        widget.display_order(SAMPLE_ITEMS, EMPTY_STATE)
+
+        received = []
+        widget.force_complete_sku.connect(received.append)
+
+        btn = widget.table.cellWidget(0, 5)
         btn.click()
 
         assert received == ["SKU-A"]

--- a/tests/test_packer_mode_widget.py
+++ b/tests/test_packer_mode_widget.py
@@ -56,10 +56,9 @@ SAMPLE_METADATA = {
     'tags': ['summer-sale'],
     'created_at': '2026-01-15T10:00:00',
     'status': 'Fulfillable',
+    'shopify_status': 'unfulfilled',
     'recommended_box': 'Box_Large',
-    'shipping_method': 'express',
     'destination': 'BG',
-    'order_type': 'Multi',
 }
 
 
@@ -437,11 +436,12 @@ class TestDisplayOrderMetadata:
         widget.display_order_metadata(SAMPLE_METADATA)
         assert not widget.metadata_frame.isHidden()
 
-    def test_status_label_populated(self, qtbot):
+    def test_shopify_status_label_populated(self, qtbot):
         widget = PackerModeWidget()
         qtbot.addWidget(widget)
         widget.display_order_metadata(SAMPLE_METADATA)
-        assert "Fulfillable" in widget.meta_status_label.text()
+        assert "unfulfilled" in widget.meta_shopify_status_label.text()
+        assert not widget.meta_shopify_status_label.isHidden()
 
     def test_courier_badge_populated(self, qtbot):
         widget = PackerModeWidget()
@@ -500,12 +500,11 @@ class TestDisplayOrderMetadata:
         assert "BG" in widget.meta_destination_label.text()
         assert not widget.meta_destination_label.isHidden()
 
-    def test_order_type_shown(self, qtbot):
+    def test_empty_shopify_status_hidden(self, qtbot):
         widget = PackerModeWidget()
         qtbot.addWidget(widget)
-        widget.display_order_metadata(SAMPLE_METADATA)
-        assert "Multi" in widget.meta_order_type_label.text()
-        assert not widget.meta_order_type_label.isHidden()
+        widget.display_order_metadata({'shopify_status': ''})
+        assert widget.meta_shopify_status_label.isHidden()
 
     def test_empty_destination_hidden(self, qtbot):
         widget = PackerModeWidget()
@@ -518,11 +517,11 @@ class TestDisplayOrderMetadata:
         qtbot.addWidget(widget)
         widget.display_order_metadata({})  # Should not raise
 
-    def test_missing_status_hides_status_label(self, qtbot):
+    def test_missing_shopify_status_hides_label(self, qtbot):
         widget = PackerModeWidget()
         qtbot.addWidget(widget)
         widget.display_order_metadata({'system_note': 'hi'})
-        assert widget.meta_status_label.isHidden()
+        assert widget.meta_shopify_status_label.isHidden()
 
 
 # ============================================================================

--- a/tests/test_state_persistence.py
+++ b/tests/test_state_persistence.py
@@ -580,8 +580,8 @@ class TestCrashRecovery(unittest.TestCase):
         # Create PackerLogic instance - should handle corruption gracefully
         packer = PackerLogic("TEST", self.mock_profile_manager, str(self.work_dir))
 
-        # Verify it starts with fresh state
-        self.assertEqual(packer.session_packing_state, {'in_progress': {}, 'completed_orders': []})
+        # Verify it starts with fresh state (skipped_orders added in v1.3.x)
+        self.assertEqual(packer.session_packing_state, {'in_progress': {}, 'completed_orders': [], 'skipped_orders': []})
         self.assertIsNone(packer.session_id)
 
     def test_state_metadata_complete(self):


### PR DESCRIPTION
…ress, UX

- Layout: top session progress strip + QSplitter (summary | table | controls) + bottom metadata badge strip
- Extended Shopify metadata: system_note, internal_tags, tags, created_at, recommended_box, shipping_method, status extracted into orders_data[n]['metadata'] and displayed as badges
- Skip order: skip_order() preserves in_progress state; skipped orders ignored for session end trigger
- Force complete: per-row Force button emits force_complete_sku(str); sets packed=required and advances order
- Session progress: update_session_progress(completed, total) updates top strip; _check_session_completion() triggers _offer_session_end() dialog when all non-skipped orders done
- Qty > 1 highlighting: bold font + #5a4a00 bg / #ffc107 fg in table and summary
- History: 2-column table (order | items count) + prev_order_table shows completed order items dimmed
- SKU_EXTRA: distinct "ALREADY PACKED!" orange notification (was same as SKU_NOT_FOUND)
- Window: starts maximized (1400×900, min 1100×700)
- Robustness: defensive in_progress access via get/setdefault; courier normalized to str with N/A fallback; public normalize_sku() API; update_item_row row bounds check; explicit Pending colors (#1a3550 / #90caf9) replacing palette-derived; set() dedup in session end count
- Tests: 447 pass (+69 new), 10 skipped, 1 flaky excluded