### PR TITLE
feat: packer mode enhancements — metadata, extras, layout, icon buttons

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ if str(project_root) not in sys.path:
 from PySide6.QtWidgets import (
     QApplication, QMainWindow, QLabel, QPushButton, QVBoxLayout, QWidget, QFileDialog, QStackedWidget,
     QHBoxLayout, QMessageBox, QLineEdit, QComboBox, QDialog, QFormLayout, QDialogButtonBox, QTabWidget,
-    QTreeWidget, QTreeWidgetItem, QTableWidget, QTableWidgetItem, QGroupBox, QScrollArea
+    QTreeWidget, QTreeWidgetItem, QTableWidget, QTableWidgetItem, QGroupBox, QScrollArea, QInputDialog
 )
 from PySide6.QtGui import QAction, QFont, QCloseEvent, QKeySequence
 from PySide6.QtCore import QTimer, QSettings, QSize, Qt
@@ -280,6 +280,12 @@ class MainWindow(QMainWindow):
         self.packer_mode_widget = PackerModeWidget(sim_mode=self._sim_mode)
         self.packer_mode_widget.barcode_scanned.connect(self.on_scanner_input)
         self.packer_mode_widget.exit_packing_mode.connect(self.switch_to_session_view)
+        self.packer_mode_widget.skip_order_requested.connect(self._on_skip_order)
+        self.packer_mode_widget.cancel_item_requested.connect(self._on_cancel_item)
+        self.packer_mode_widget.force_confirm_requested.connect(self._on_force_confirm)
+        self.packer_mode_widget.map_sku_requested.connect(self._on_map_sku_from_packer)
+        self.packer_mode_widget.extra_confirmed.connect(self._on_extra_confirmed)
+        self.packer_mode_widget.extra_removed.connect(self._on_extra_removed)
 
         # Stacked widget to switch between session view and packer mode
         self.stacked_widget = QStackedWidget()
@@ -1069,6 +1075,7 @@ class MainWindow(QMainWindow):
 
             # Connect signals
             self.logic.item_packed.connect(self._on_item_packed)
+            self.logic.all_orders_complete.connect(self._on_all_orders_complete)
 
             # Load Shopify session data
             session_path = self.session_manager.output_dir
@@ -1373,6 +1380,7 @@ class MainWindow(QMainWindow):
 
             # 6. Connect signals
             self.logic.item_packed.connect(self._on_item_packed)
+            self.logic.all_orders_complete.connect(self._on_all_orders_complete)
 
             # 7. Load packing data into PackerLogic
             order_count, list_name = self.logic.load_packing_list_json(str(packing_list_path))
@@ -1876,7 +1884,17 @@ class MainWindow(QMainWindow):
             items, status = self.logic.start_order_packing(text)
             if status == "ORDER_LOADED":
                 self.packer_mode_widget.add_order_to_history(order_number_from_scan)
-                self.packer_mode_widget.display_order(items, self.logic.current_order_state)
+                order_metadata = self.logic.orders_data.get(
+                    order_number_from_scan, {}
+                ).get('metadata', {})
+                self.packer_mode_widget.display_order(
+                    items,
+                    self.logic.current_order_state,
+                    metadata=order_metadata,
+                    sku_map=self.logic.sku_map,
+                )
+                completed = len(self.logic.session_packing_state.get('completed_orders', []))
+                self.packer_mode_widget.update_session_progress(completed, len(self.logic.orders_data))
                 self.update_order_status(order_number_from_scan, "In Progress")
             else:
                 self.packer_mode_widget.show_notification("ORDER NOT FOUND", "#c0392b")
@@ -1887,19 +1905,29 @@ class MainWindow(QMainWindow):
                 self.packer_mode_widget.update_item_row(result["row"], result["packed"], result["is_complete"])
                 self.flash_border("green")
             elif status == "SKU_NOT_FOUND":
-                self.packer_mode_widget.show_notification("INCORRECT ITEM!", "#c0392b")
+                unknown_list = self.logic.unknown_scans
+                if len(unknown_list) > 1:
+                    detail = f"({len(unknown_list)} unknown scans)\nLast: {text}"
+                else:
+                    detail = f"Unknown: {text}"
+                self.packer_mode_widget.show_notification(
+                    f"INCORRECT ITEM!\n{detail}", "#c0392b"
+                )
                 self.flash_border("red")
+            elif status == "SKU_EXTRA":
+                self.packer_mode_widget.show_notification("EXTRA ITEM!", "#b06020")
+                self.flash_border("orange")
+                self.packer_mode_widget.show_extras_panel(self.logic.current_extra_items)
+            elif status == "ORDER_COMPLETE_WITH_EXTRAS":
+                self.packer_mode_widget.update_item_row(result["row"], result["packed"], result["is_complete"])
+                self.packer_mode_widget.show_notification("REVIEW EXTRA ITEMS!", "#e67e22")
+                self.flash_border("orange")
+                self.packer_mode_widget.show_extras_panel(self.logic.current_extra_items)
             elif status == "ORDER_COMPLETE":
                 current_order_num = self.logic.current_order_number
-                # Phase 1.4: No need to record individual order completion - only record at session completion
-
                 self.packer_mode_widget.update_item_row(result["row"], result["packed"], result["is_complete"])
-                self.packer_mode_widget.show_notification(f"ORDER {current_order_num} COMPLETE!", "#43a047")
-                self.flash_border("green")
-                self.update_order_status(current_order_num, "Completed")
-                self.packer_mode_widget.scanner_input.setEnabled(False)
+                self._handle_order_completion(current_order_num)
                 self.logic.clear_current_order()
-                QTimer.singleShot(3000, self.packer_mode_widget.clear_screen)
 
     # REMOVED: _process_shopify_packing_data() method (dead code)
     # This method was never called. Functionality replaced by PackerLogic.load_packing_list_json()
@@ -1934,6 +1962,151 @@ class MainWindow(QMainWindow):
         self._populate_order_tree()
         self._update_statistics()
         logger.debug(f"Order {order_number} status updated to: {status}")
+
+    # ─── Packer Mode new action handlers ─────────────────────────────────────
+
+    def _handle_order_completion(self, order_number: str):
+        """Shared teardown for every order-complete path (scan, force confirm, extra resolve)."""
+        self.packer_mode_widget.show_notification(f"ORDER {order_number} COMPLETE!", "#43a047")
+        self.flash_border("green")
+        self.update_order_status(order_number, "Completed")
+        if self.logic:
+            completed = len(self.logic.session_packing_state.get('completed_orders', []))
+            self.packer_mode_widget.update_session_progress(completed, len(self.logic.orders_data))
+        self.packer_mode_widget.scanner_input.setEnabled(False)
+        QTimer.singleShot(3000, self.packer_mode_widget.clear_screen)
+
+    def _on_skip_order(self):
+        """Skip the currently active order (preserves packing progress for later)."""
+        if not self.logic or not self.logic.current_order_number:
+            return
+        skipped = self.logic.current_order_number
+        self.logic.clear_current_order()
+        self.packer_mode_widget.add_order_to_history(skipped, "[SKIPPED]")
+        self.packer_mode_widget.clear_screen()
+        logger.info(f"Order {skipped} skipped")
+
+    def _on_cancel_item(self, row: int):
+        """Handle -1 (undo last scan) for a specific item row."""
+        if not self.logic:
+            return
+        result, status = self.logic.cancel_item_scan(row)
+        if status == "ITEM_DECREMENTED":
+            self.packer_mode_widget.update_item_row(row, result["packed"], False)
+            self.flash_border("orange")
+        elif status == "ITEM_ALREADY_ZERO":
+            self.packer_mode_widget.show_notification("Already at 0!", "#b06020")
+        self.packer_mode_widget.set_focus_to_scanner()
+
+    def _on_force_confirm(self, row: int):
+        """Handle Force Confirm for a specific item row."""
+        if not self.logic:
+            return
+        result, status = self.logic.force_confirm_item(row)
+        if status == "FORCE_CONFIRMED":
+            self.packer_mode_widget.update_item_row(row, result["packed"], True)
+            self.flash_border("green")
+            if result.get("order_complete"):
+                order_num = self.logic.current_order_number
+                self._handle_order_completion(order_num)
+                self.logic.clear_current_order()
+        self.packer_mode_widget.set_focus_to_scanner()
+
+    def _on_map_sku_from_packer(self, sku: str):
+        """Quick-add barcode→SKU mapping from packer mode.
+
+        Pre-populates the SKU so the worker only needs to scan/type the barcode.
+        The barcode field is left empty for the scanner to fill in.
+        """
+        if not self.current_client_id:
+            self.packer_mode_widget.set_focus_to_scanner()
+            return
+
+        barcode, ok = QInputDialog.getText(
+            self,
+            "Map Barcode to SKU",
+            f"SKU:  {sku}\n\nScan or type the product barcode to map to this SKU:",
+        )
+        if not (ok and barcode and barcode.strip()):
+            self.packer_mode_widget.set_focus_to_scanner()
+            return
+
+        barcode = barcode.strip()
+        try:
+            existing = self.profile_manager.load_sku_mapping(self.current_client_id)
+            if barcode in existing and existing[barcode] != sku:
+                reply = QMessageBox.question(
+                    self,
+                    "Overwrite Mapping?",
+                    f"Barcode '{barcode}' already maps to '{existing[barcode]}'.\n\n"
+                    f"Replace with '{sku}'?",
+                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                    QMessageBox.StandardButton.No,
+                )
+                if reply != QMessageBox.StandardButton.Yes:
+                    self.packer_mode_widget.set_focus_to_scanner()
+                    return
+
+            existing[barcode] = sku
+            success = self.profile_manager.save_sku_mapping(self.current_client_id, existing)
+            if success:
+                if self.logic:
+                    self.logic.sku_map = {
+                        self.logic._normalize_sku(k): v for k, v in existing.items()
+                    }
+                    logger.info(f"Quick-mapped barcode '{barcode}' → SKU '{sku}'")
+                self.packer_mode_widget.show_notification(f"Mapped: {barcode} → {sku}", "#43a047")
+            else:
+                QMessageBox.warning(self, "Save Failed", "Could not save mapping to file server.")
+        except Exception as e:
+            logger.error(f"Failed to save quick SKU mapping: {e}")
+            QMessageBox.critical(self, "Error", f"Failed to save mapping:\n\n{e}")
+
+        self.packer_mode_widget.set_focus_to_scanner()
+
+    def _on_extra_confirmed(self, norm_sku: str):
+        """Handle 'Keep' for an extra item — user acknowledges it is intentional."""
+        if not self.logic:
+            return
+        _, status = self.logic.confirm_keep_extra(norm_sku)
+        self.packer_mode_widget.show_extras_panel(self.logic.current_extra_items)
+        if status == "ORDER_NOW_COMPLETE":
+            order_num = self.logic.current_order_number
+            self._handle_order_completion(order_num)
+            self.logic.clear_current_order()
+        elif status == "EXTRA_CLEARED":
+            self.packer_mode_widget.show_notification(
+                "Extra cleared — continue scanning", "#43a047"
+            )
+        self.packer_mode_widget.set_focus_to_scanner()
+
+    def _on_extra_removed(self, norm_sku: str):
+        """Handle 'Remove' for an extra item — user acknowledges it was a mistake."""
+        if not self.logic:
+            return
+        _, status = self.logic.remove_extra_item(norm_sku)
+        self.packer_mode_widget.show_extras_panel(self.logic.current_extra_items)
+        if status == "ORDER_NOW_COMPLETE":
+            order_num = self.logic.current_order_number
+            self._handle_order_completion(order_num)
+            self.logic.clear_current_order()
+        elif status == "EXTRA_CLEARED":
+            self.packer_mode_widget.show_notification(
+                "Extra cleared — continue scanning", "#43a047"
+            )
+        self.packer_mode_widget.set_focus_to_scanner()
+
+    def _on_all_orders_complete(self):
+        """Handle the all_orders_complete signal — offer to end session."""
+        reply = QMessageBox.question(
+            self,
+            "All Orders Packed",
+            "All orders have been packed!\nEnd session now?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.Yes,
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            self.end_session()
 
     # REMOVED: open_restore_session_dialog() method (dead code)
     # This method was never called. Functionality replaced by Session Browser's
@@ -2111,6 +2284,7 @@ class MainWindow(QMainWindow):
 
                 # Connect signals
                 self.logic.item_packed.connect(self._on_item_packed)
+                self.logic.all_orders_complete.connect(self._on_all_orders_complete)
 
                 # Start heartbeat timer
                 self._start_heartbeat_timer()

--- a/src/packer_mode_widget.py
+++ b/src/packer_mode_widget.py
@@ -1,12 +1,13 @@
 import logging
+from collections import defaultdict
 from functools import partial
 from PySide6.QtWidgets import (
     QWidget, QHBoxLayout, QVBoxLayout, QTableWidget, QTableWidgetItem,
     QLabel, QLineEdit, QHeaderView, QPushButton, QAbstractItemView, QFrame,
-    QGroupBox
+    QGroupBox, QProgressBar, QMessageBox, QApplication, QStyle
 )
-from PySide6.QtGui import QFont, QColor, QPalette
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QFont, QColor, QPalette, QIcon
+from PySide6.QtCore import Qt, Signal, QSize
 from typing import List, Dict, Any
 
 logger = logging.getLogger(__name__)
@@ -17,27 +18,35 @@ class PackerModeWidget(QWidget):
 
     This widget displays the items for the currently active order, provides
     visual feedback on scanning actions, and captures input from a barcode
-
     scanner. It is designed to be a dedicated, focused view for the packing
     process.
 
     Attributes:
-        barcode_scanned (Signal): Emitted when a barcode is scanned (i.e., when
-                                  Enter is pressed in the scanner_input).
+        barcode_scanned (Signal): Emitted when a barcode is scanned.
         exit_packing_mode (Signal): Emitted when the user clicks the exit button.
-        table_frame (QFrame): A frame around the items table used for flashing
-                              visual feedback (e.g., green/red border).
-        table (QTableWidget): The table displaying the SKUs for the current order.
-        status_label (QLabel): A label showing the current order's status.
-        notification_label (QLabel): A large label for showing prominent
-                                     notifications (e.g., "ORDER COMPLETE").
-        scanner_input (QLineEdit): A hidden line edit that captures keystrokes
-                                   from a USB barcode scanner.
-        raw_scan_label (QLabel): A label to display the raw text from the last scan.
-        history_table (QTableWidget): A table showing a history of scanned orders.
+        skip_order_requested (Signal): Emitted when the skip order button is clicked.
+        cancel_item_requested (Signal[int]): Emitted with row index on -1 button press.
+        force_confirm_requested (Signal[int]): Emitted with row index on Force Confirm.
+        map_sku_requested (Signal[str]): Emitted with original SKU on Map SKU press.
+        extra_confirmed (Signal[str]): Emitted with normalized_sku on Keep extra.
+        extra_removed (Signal[str]): Emitted with normalized_sku on Remove extra.
+        table_frame (QFrame): Frame around items table used for flashing visual feedback.
+        table (QTableWidget): Table displaying the SKUs for the current order.
+        session_progress_bar (QProgressBar): Shows completed/total orders for the session.
+        status_label (QLabel): Shows current order status.
+        notification_label (QLabel): Large label for prominent notifications.
+        scanner_input (QLineEdit): Hidden line edit that captures barcode scanner input.
+        raw_scan_label (QLabel): Shows raw text from the last scan.
+        history_table (QTableWidget): History of scanned orders in this session.
     """
-    barcode_scanned = Signal(str)
-    exit_packing_mode = Signal()
+    barcode_scanned        = Signal(str)
+    exit_packing_mode      = Signal()
+    skip_order_requested   = Signal()
+    cancel_item_requested  = Signal(int)   # row index
+    force_confirm_requested = Signal(int)  # row index
+    map_sku_requested      = Signal(str)   # original SKU string
+    extra_confirmed        = Signal(str)   # normalized_sku
+    extra_removed          = Signal(str)   # normalized_sku
 
     FRAME_DEFAULT_STYLE = "QFrame#TableFrame { border: 1px solid palette(mid); border-radius: 3px; }"
 
@@ -55,9 +64,54 @@ class PackerModeWidget(QWidget):
 
         main_layout = QHBoxLayout(self)
 
+        # ─── LEFT PANEL ──────────────────────────────────────────────────────
         left_widget = QWidget()
         left_layout = QVBoxLayout(left_widget)
+        left_layout.setSpacing(4)
 
+        # [B] Session progress bar
+        self.session_progress_bar = QProgressBar()
+        self.session_progress_bar.setFixedHeight(18)
+        self.session_progress_bar.setTextVisible(True)
+        self.session_progress_bar.setFormat("0 / 0 orders")
+        self.session_progress_bar.setValue(0)
+        self.session_progress_bar.setMaximum(1)
+        left_layout.addWidget(self.session_progress_bar)
+
+        # [A] Order metadata banner (hidden until an order is loaded)
+        self.metadata_banner = QFrame()
+        self.metadata_banner.setObjectName("MetadataBanner")
+        self.metadata_banner.setStyleSheet(
+            "QFrame#MetadataBanner { border: 1px solid palette(mid); border-radius: 3px; "
+            "background-color: palette(alternate-base); }"
+        )
+        self.metadata_banner.setVisible(False)
+        _mbl = QHBoxLayout(self.metadata_banner)
+        _mbl.setContentsMargins(6, 3, 6, 3)
+        _mbl.setSpacing(6)
+        _chip_style = (
+            "QLabel { border: 1px solid palette(mid); border-radius: 4px; "
+            "padding: 2px 7px; background-color: palette(button); }"
+        )
+        self._meta_type_lbl    = QLabel()
+        self._meta_courier_lbl = QLabel()
+        self._meta_country_lbl = QLabel()
+        self._meta_box_lbl     = QLabel()
+        self._meta_tags_lbl    = QLabel()
+        self._meta_notes_lbl   = QLabel()
+        self._meta_notes_lbl.setWordWrap(True)
+        for lbl in [self._meta_type_lbl, self._meta_courier_lbl,
+                    self._meta_country_lbl, self._meta_box_lbl,
+                    self._meta_tags_lbl, self._meta_notes_lbl]:
+            f = lbl.font(); f.setPointSize(9); lbl.setFont(f)
+            lbl.setStyleSheet(_chip_style)
+            lbl.setVisible(False)
+            _mbl.addWidget(lbl)
+        # Notes label takes remaining space
+        _mbl.setStretchFactor(self._meta_notes_lbl, 1)
+        left_layout.addWidget(self.metadata_banner)
+
+        # Items table inside a frame
         self.table_frame = QFrame()
         self.table_frame.setObjectName("TableFrame")
         self.table_frame.setFrameShape(QFrame.Shape.Box)
@@ -68,9 +122,15 @@ class PackerModeWidget(QWidget):
 
         self.table = QTableWidget()
         self.table.setColumnCount(5)
-        self.table.setHorizontalHeaderLabels(["Product Name", "SKU", "Packed / Required", "Status", "Action"])
-        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
-        self.table.horizontalHeader().setStretchLastSection(True)
+        self.table.setHorizontalHeaderLabels(["Product Name", "SKU", "Qty", "Status", "Actions"])
+        hdr = self.table.horizontalHeader()
+        hdr.setSectionResizeMode(0, QHeaderView.Stretch)
+        hdr.setSectionResizeMode(1, QHeaderView.ResizeToContents)
+        hdr.setSectionResizeMode(2, QHeaderView.ResizeToContents)
+        hdr.setSectionResizeMode(3, QHeaderView.ResizeToContents)
+        hdr.setSectionResizeMode(4, QHeaderView.Fixed)
+        hdr.resizeSection(4, 135)
+        hdr.setStretchLastSection(False)
         self.table.setEditTriggers(QTableWidget.NoEditTriggers)
         self.table.setSelectionMode(QAbstractItemView.NoSelection)
         self.table.setFocusPolicy(Qt.NoFocus)
@@ -78,6 +138,46 @@ class PackerModeWidget(QWidget):
         frame_layout.addWidget(self.table)
         left_layout.addWidget(self.table_frame)
 
+        # Scanned Orders History — compact panel below the items table (left panel)
+        _hist_title = QLabel("Scanned Orders History:")
+        _hist_title.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        _hf = _hist_title.font(); _hf.setPointSize(9); _hist_title.setFont(_hf)
+        left_layout.addWidget(_hist_title)
+
+        self.history_table = QTableWidget()
+        self.history_table.setColumnCount(1)
+        self.history_table.setHorizontalHeaderLabels(["Order #"])
+        self.history_table.horizontalHeader().setStretchLastSection(True)
+        self.history_table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.history_table.setSelectionMode(QAbstractItemView.NoSelection)
+        self.history_table.setFocusPolicy(Qt.NoFocus)
+        self.history_table.setMaximumHeight(90)
+        left_layout.addWidget(self.history_table)
+
+        # [D] Summary panel — deduped SKUs with summed quantities (hidden until order loaded)
+        self.summary_frame = QFrame()
+        self.summary_frame.setObjectName("SummaryFrame")
+        self.summary_frame.setStyleSheet(
+            "QFrame#SummaryFrame { border: 1px solid palette(mid); border-radius: 3px; }"
+        )
+        self.summary_frame.setVisible(False)
+        _sfl = QVBoxLayout(self.summary_frame)
+        _sfl.setContentsMargins(4, 2, 4, 2)
+        _sfl.setSpacing(2)
+        _sh = QLabel("Summary (unique SKUs):")
+        _shf = _sh.font(); _shf.setPointSize(9); _sh.setFont(_shf)
+        _sfl.addWidget(_sh)
+        self.summary_table = QTableWidget()
+        self.summary_table.setColumnCount(3)
+        self.summary_table.setHorizontalHeaderLabels(["SKU", "Packed/Total", "Status"])
+        self.summary_table.horizontalHeader().setStretchLastSection(True)
+        self.summary_table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.summary_table.setSelectionMode(QAbstractItemView.NoSelection)
+        self.summary_table.setFocusPolicy(Qt.NoFocus)
+        _sfl.addWidget(self.summary_table)
+        # summary_frame lives in the right panel (added there below)
+
+        # ─── RIGHT PANEL ─────────────────────────────────────────────────────
         right_widget = QWidget()
         right_layout = QVBoxLayout(right_widget)
         right_layout.setAlignment(Qt.AlignCenter)
@@ -117,6 +217,34 @@ class PackerModeWidget(QWidget):
         right_layout.addWidget(self.notification_label)
         right_layout.addStretch()
 
+        # [D] Summary panel — inserted here in the right panel
+        right_layout.addWidget(self.summary_frame)
+
+        # [J] Extra items panel (hidden by default, shown when extras detected)
+        self.extras_panel = QFrame()
+        self.extras_panel.setObjectName("ExtrasPanel")
+        self.extras_panel.setStyleSheet(
+            "QFrame#ExtrasPanel { border: 2px solid #b06020; border-radius: 3px; }"
+        )
+        self.extras_panel.setVisible(False)
+        _epl = QVBoxLayout(self.extras_panel)
+        _epl.setContentsMargins(4, 4, 4, 4)
+        _epl.setSpacing(3)
+        _et = QLabel("EXTRA ITEMS DETECTED")
+        _et.setAlignment(Qt.AlignCenter)
+        _et.setStyleSheet("color: #e67e22; font-weight: bold;")
+        _epl.addWidget(_et)
+        self.extras_table = QTableWidget()
+        self.extras_table.setColumnCount(3)
+        self.extras_table.setHorizontalHeaderLabels(["SKU", "×", "Action"])
+        self.extras_table.horizontalHeader().setStretchLastSection(True)
+        self.extras_table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.extras_table.setSelectionMode(QAbstractItemView.NoSelection)
+        self.extras_table.setFocusPolicy(Qt.NoFocus)
+        self.extras_table.setMaximumHeight(130)
+        _epl.addWidget(self.extras_table)
+        right_layout.addWidget(self.extras_panel)
+
         raw_scan_title = QLabel("Last Scan:")
         raw_scan_title.setAlignment(Qt.AlignCenter)
         self.raw_scan_label = QLabel("-")
@@ -124,31 +252,21 @@ class PackerModeWidget(QWidget):
         self.raw_scan_label.setObjectName("RawScanLabel")
         self.raw_scan_label.setWordWrap(True)
 
-        history_title = QLabel("Scanned Orders History:")
-        history_title.setAlignment(Qt.AlignCenter)
-        self.history_table = QTableWidget()
-        self.history_table.setColumnCount(1)
-        self.history_table.setHorizontalHeaderLabels(["Order #"])
-        self.history_table.horizontalHeader().setStretchLastSection(True)
-        self.history_table.setEditTriggers(QTableWidget.NoEditTriggers)
-        self.history_table.setSelectionMode(QAbstractItemView.NoSelection)
-        self.history_table.setFocusPolicy(Qt.NoFocus)
-
-        info_container = QWidget()
-        info_layout = QVBoxLayout(info_container)
-        info_layout.setContentsMargins(0,0,0,0)
-        info_layout.addWidget(raw_scan_title)
-        info_layout.addWidget(self.raw_scan_label)
-        info_layout.addWidget(history_title)
-        info_layout.addWidget(self.history_table)
-
-        right_layout.addWidget(info_container)
+        right_layout.addWidget(raw_scan_title)
+        right_layout.addWidget(self.raw_scan_label)
         right_layout.addStretch()
 
         self.scanner_input = QLineEdit()
         self.scanner_input.setFixedSize(1, 1)
         self.scanner_input.returnPressed.connect(self._on_scan)
         right_layout.addWidget(self.scanner_input)
+
+        # [E] Skip Order button (disabled until an order is loaded)
+        self.skip_order_button = QPushButton("Skip Order →")
+        self.skip_order_button.setFocusPolicy(Qt.NoFocus)
+        self.skip_order_button.setEnabled(False)
+        self.skip_order_button.clicked.connect(self.skip_order_requested.emit)
+        right_layout.addWidget(self.skip_order_button)
 
         right_layout.addStretch()
         self.exit_button = QPushButton("<< Back to Menu")
@@ -159,6 +277,8 @@ class PackerModeWidget(QWidget):
 
         main_layout.addWidget(left_widget, stretch=2)
         main_layout.addWidget(right_widget, stretch=1)
+
+    # ─── Scanner input handlers ───────────────────────────────────────────────
 
     def _on_scan(self):
         """
@@ -182,42 +302,97 @@ class PackerModeWidget(QWidget):
             self.sim_input.clear()
             self.barcode_scanned.emit(text)
 
+    # ─── Action button slots ──────────────────────────────────────────────────
+
     def _on_manual_confirm(self, sku: str):
         """
         Private slot for the 'Confirm Manually' button. Emits the
         barcode_scanned signal with the SKU for the corresponding row.
-
-        Args:
-            sku (str): The SKU of the item to confirm.
         """
         if sku:
             self.barcode_scanned.emit(sku)
         self.set_focus_to_scanner()
 
-    def display_order(self, items: List[Dict[str, Any]], order_state: List[Dict[str, Any]]):
+    def _on_cancel_item(self, row: int):
+        """Show confirmation dialog then emit cancel_item_requested."""
+        reply = QMessageBox.question(
+            self, "Undo Scan",
+            "Undo the last scan for this item?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            self.cancel_item_requested.emit(row)
+        self.set_focus_to_scanner()
+
+    def _on_force_confirm(self, row: int):
+        """Show confirmation dialog then emit force_confirm_requested."""
+        reply = QMessageBox.question(
+            self, "Force Confirm",
+            "Force-confirm ALL remaining quantity for this item?\nThis cannot be undone.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            self.force_confirm_requested.emit(row)
+        self.set_focus_to_scanner()
+
+    def _on_map_sku_requested(self, sku: str):
+        """Emit map_sku_requested with the original SKU string."""
+        self.map_sku_requested.emit(sku)
+        self.set_focus_to_scanner()
+
+    def _on_extra_confirmed(self, norm_sku: str):
+        """Emit extra_confirmed for the given normalized SKU."""
+        self.extra_confirmed.emit(norm_sku)
+        self.set_focus_to_scanner()
+
+    def _on_extra_removed(self, norm_sku: str):
+        """Emit extra_removed for the given normalized SKU."""
+        self.extra_removed.emit(norm_sku)
+        self.set_focus_to_scanner()
+
+    # ─── Public display methods ───────────────────────────────────────────────
+
+    def display_order(
+        self,
+        items: List[Dict[str, Any]],
+        order_state: List[Dict[str, Any]],
+        metadata: Dict[str, Any] = None,
+        sku_map: Dict[str, str] = None,
+    ):
         """
         Populates the items table with the details of the current order.
 
-        It clears the table and then fills it with the products for the given
-        order. It also updates the display based on any existing progress
-        (e.g., if the order was partially packed in a previous session).
-
         Args:
-            items (List[Dict[str, Any]]): A list of dictionaries, where each
-                                          represents a product in the order.
-            order_state (List[Dict[str, Any]]): The current packing state for the
-                                                order, showing packed counts for each row.
+            items: List of product dicts for the order.
+            order_state: Current packing state (packed counts per row).
+            metadata: Optional order-level metadata dict (tags, notes, etc.).
+            sku_map: Optional normalized barcode→SKU mapping for Map SKU detection.
         """
+        # [A] Show metadata banner if available
+        self._update_metadata_banner(metadata)
+
         self.table.setRowCount(len(items))
 
         # First, populate the table with all items as 'Pending'
         for row, item in enumerate(items):
             sku = item.get('SKU', '')
-            quantity = str(item.get('Quantity', ''))
+            quantity_str = str(item.get('Quantity', ''))
+            try:
+                quantity_int = int(float(quantity_str))
+            except (ValueError, TypeError):
+                quantity_int = 1
 
             self.table.setItem(row, 0, QTableWidgetItem(item.get('Product_Name', '')))
             self.table.setItem(row, 1, QTableWidgetItem(sku))
-            self.table.setItem(row, 2, QTableWidgetItem(f"0 / {quantity}")) # Default to 0 packed
+
+            # [C] Amber highlight when quantity > 1
+            qty_item = QTableWidgetItem(f"0 / {quantity_int}")
+            if quantity_int > 1:
+                qty_item.setBackground(QColor("#5a4000"))
+                qty_item.setForeground(QColor("#f39c12"))
+            self.table.setItem(row, 2, qty_item)
 
             status_item = QTableWidgetItem("Pending")
             palette = self.table.palette()
@@ -227,23 +402,27 @@ class PackerModeWidget(QWidget):
             status_item.setForeground(pending_fg)
             self.table.setItem(row, 3, status_item)
 
-            confirm_button = QPushButton("Confirm Manually")
-            confirm_button.setFocusPolicy(Qt.NoFocus)
-            confirm_button.clicked.connect(partial(self._on_manual_confirm, sku))
-            self.table.setCellWidget(row, 4, confirm_button)
+            # Actions column: Confirm / -1 / Force / Map
+            actions_widget = self._make_actions_widget(row, sku, quantity_int, sku_map or {})
+            self.table.setCellWidget(row, 4, actions_widget)
 
-        # Now, iterate through the state list and update rows that have progress
+        # Now update rows that have existing progress (e.g., resumed order)
         for state_item in order_state:
             row_index = state_item.get('row')
             packed_count = state_item.get('packed', 0)
-
-            # Check if the row index is valid and if there's anything packed
             if row_index is not None and packed_count > 0 and row_index < self.table.rowCount():
                 required_count = state_item.get('required', 1)
                 is_complete = packed_count >= required_count
                 self.update_item_row(row_index, packed_count, is_complete)
 
-        self.status_label.setText(f"Order {items[0]['Order_Number']}\nIn Progress...")
+        # [D] Update summary panel
+        self._update_summary_panel(items, order_state)
+
+        # [E] Enable skip button now that an order is active
+        self.skip_order_button.setEnabled(True)
+
+        order_num = items[0].get('Order_Number', items[0].get('order_number', ''))
+        self.status_label.setText(f"Order {order_num}\nIn Progress...")
         self.set_focus_to_scanner()
 
     def update_item_row(self, row: int, packed_count: int, is_complete: bool):
@@ -251,33 +430,57 @@ class PackerModeWidget(QWidget):
         Updates a single row in the items table to reflect a new packed count.
 
         Args:
-            row (int): The table row index to update.
-            packed_count (int): The new number of items packed for that SKU.
-            is_complete (bool): Whether this SKU is now fully packed.
+            row: The table row index to update.
+            packed_count: The new number of items packed for that SKU.
+            is_complete: Whether this SKU is now fully packed.
         """
-        # Check if table item exists before accessing
         quantity_item = self.table.item(row, 2)
         if quantity_item is None:
             logger.warning(f"Cannot update row {row}: quantity item is None")
             return
 
-        required_quantity = quantity_item.text().split(' / ')[1]
-        quantity_item.setText(f"{packed_count} / {required_quantity}")
+        parts = quantity_item.text().split(' / ')
+        required_str = parts[1] if len(parts) > 1 else '1'
+        quantity_item.setText(f"{packed_count} / {required_str}")
+
+        try:
+            req_int = int(required_str)
+        except ValueError:
+            req_int = 1
 
         if is_complete:
             status_item = QTableWidgetItem("Packed")
             status_item.setBackground(QColor("#1e4d2b"))  # muted dark green
             status_item.setForeground(QColor("#43a047"))
             self.table.setItem(row, 3, status_item)
-            self.table.cellWidget(row, 4).setEnabled(False)
+            # Clear amber on completion — use palette text color to avoid black-on-dark rendering
+            quantity_item.setBackground(QColor())
+            quantity_item.setForeground(
+                self.table.palette().color(QPalette.ColorRole.Text)
+            )
+            # Disable Confirm and Force buttons; leave -1 active for possible undo
+            cell_widget = self.table.cellWidget(row, 4)
+            if cell_widget:
+                for btn in cell_widget.findChildren(QPushButton):
+                    tip = btn.toolTip()
+                    if tip in ("Confirm Manually", "Force confirm all remaining quantity (qty > 5 only)"):  # noqa: E501
+                        btn.setEnabled(False)
+        else:
+            # Re-apply amber highlight for multi-qty items still in progress
+            if req_int > 1:
+                quantity_item.setBackground(QColor("#5a4000"))
+                quantity_item.setForeground(QColor("#f39c12"))
+
+        # [Fix 8] Keep summary panel live during scanning
+        self._refresh_summary_from_table()
 
     def show_notification(self, text: str, color_name: str):
         """
         Displays a large, colored notification message.
 
         Args:
-            text (str): The message to display.
-            color_name (str): The name of the color for the text (e.g., "red").
+            text: The message to display.
+            color_name: The color string for the text (e.g., "#c0392b" or "red").
         """
         self.notification_label.setText(text)
         self.notification_label.setStyleSheet(f"color: {color_name};")
@@ -292,6 +495,16 @@ class PackerModeWidget(QWidget):
         self.notification_label.setText("")
         self.scanner_input.clear()
         self.scanner_input.setEnabled(True)
+        # [A] Hide metadata banner
+        self.metadata_banner.setVisible(False)
+        # [D] Hide summary panel
+        self.summary_frame.setVisible(False)
+        self.summary_table.setRowCount(0)
+        # [E] Disable skip button
+        self.skip_order_button.setEnabled(False)
+        # [J] Hide extras panel
+        self.extras_panel.setVisible(False)
+        self.extras_table.setRowCount(0)
         self.set_focus_to_scanner()
 
     def set_focus_to_scanner(self):
@@ -306,16 +519,272 @@ class PackerModeWidget(QWidget):
         Updates the label that shows the raw text from the last scan.
 
         Args:
-            text (str): The text captured from the scanner.
+            text: The text captured from the scanner.
         """
         self.raw_scan_label.setText(text)
 
-    def add_order_to_history(self, order_number: str):
+    def add_order_to_history(self, order_number: str, status: str = ""):
         """
         Adds an order number to the top of the scan history table.
 
         Args:
-            order_number (str): The order number that was just scanned.
+            order_number: The order number that was just scanned.
+            status: Optional status suffix, e.g. "[SKIPPED]".
         """
         self.history_table.insertRow(0)
-        self.history_table.setItem(0, 0, QTableWidgetItem(str(order_number)))
+        display_text = f"{order_number} {status}".strip()
+        item = QTableWidgetItem(display_text)
+        if status == "[SKIPPED]":
+            item.setForeground(QColor("#b06020"))
+        self.history_table.setItem(0, 0, item)
+
+    # [B] Feature B ────────────────────────────────────────────────────────────
+
+    def update_session_progress(self, completed: int, total: int):
+        """
+        Updates the session progress bar at the top of the left panel.
+
+        Args:
+            completed: Number of completed orders.
+            total: Total orders in the session.
+        """
+        self.session_progress_bar.setMaximum(max(total, 1))
+        self.session_progress_bar.setValue(completed)
+        self.session_progress_bar.setFormat(f"{completed} / {total} orders")
+
+    # [J] Feature J ────────────────────────────────────────────────────────────
+
+    def show_extras_panel(self, extras: Dict[str, int]):
+        """
+        Populates and shows the extras panel with Keep/Remove buttons.
+
+        Args:
+            extras: Dict of {normalized_sku: extra_count}.
+        """
+        self.extras_table.setRowCount(len(extras))
+        for i, (norm_sku, count) in enumerate(extras.items()):
+            self.extras_table.setItem(i, 0, QTableWidgetItem(norm_sku))
+            self.extras_table.setItem(i, 1, QTableWidgetItem(str(count)))
+
+            btn_widget = QWidget()
+            btn_layout = QHBoxLayout(btn_widget)
+            btn_layout.setContentsMargins(2, 1, 2, 1)
+            btn_layout.setSpacing(3)
+
+            keep_btn = QPushButton("Keep")
+            keep_btn.setFixedWidth(50)
+            keep_btn.setFocusPolicy(Qt.NoFocus)
+            keep_btn.clicked.connect(partial(self._on_extra_confirmed, norm_sku))
+
+            remove_btn = QPushButton("Remove")
+            remove_btn.setFixedWidth(60)
+            remove_btn.setFocusPolicy(Qt.NoFocus)
+            remove_btn.clicked.connect(partial(self._on_extra_removed, norm_sku))
+
+            btn_layout.addWidget(keep_btn)
+            btn_layout.addWidget(remove_btn)
+            self.extras_table.setCellWidget(i, 2, btn_widget)
+
+        self.extras_panel.setVisible(len(extras) > 0)
+
+    # ─── Private helpers ──────────────────────────────────────────────────────
+
+    def _make_actions_widget(
+        self,
+        row: int,
+        sku: str,
+        required_qty: int,
+        sku_map: Dict[str, str],
+    ) -> QWidget:
+        """
+        Builds the multi-button widget for the Actions column.
+
+        Buttons included:
+          OK   — Confirm Manually (always present)
+          -1   — Undo last scan (always present; requires confirmation dialog)
+          F✓   — Force confirm all qty (present, but enabled only when required_qty > 5)
+          Map  — Open SKU mapping dialog (only when this SKU is not a value in sku_map)
+        """
+        container = QWidget()
+        container.setFocusPolicy(Qt.NoFocus)
+        layout = QHBoxLayout(container)
+        layout.setContentsMargins(2, 1, 2, 1)
+        layout.setSpacing(3)
+
+        _style = QApplication.instance().style()
+        _icon_sz = QSize(16, 16)
+
+        def _icon_btn(sp: QStyle.StandardPixmap, tip: str, w: int) -> QPushButton:
+            btn = QPushButton()
+            btn.setIcon(_style.standardIcon(sp))
+            btn.setIconSize(_icon_sz)
+            btn.setToolTip(tip)
+            btn.setFixedWidth(w)
+            btn.setFocusPolicy(Qt.NoFocus)
+            return btn
+
+        # ✓ — Confirm Manually (equivalent to scanning the SKU barcode)
+        confirm_btn = _icon_btn(
+            QStyle.StandardPixmap.SP_DialogApplyButton,
+            "Confirm Manually",
+            28,
+        )
+        confirm_btn.clicked.connect(partial(self._on_manual_confirm, sku))
+        layout.addWidget(confirm_btn)
+
+        # ← — Undo last scan
+        minus_btn = _icon_btn(
+            QStyle.StandardPixmap.SP_ArrowLeft,
+            "Undo last scan for this item",
+            28,
+        )
+        minus_btn.clicked.connect(partial(self._on_cancel_item, row))
+        layout.addWidget(minus_btn)
+
+        # ⏩ — Force confirm all qty (enabled only when qty > 5)
+        force_btn = _icon_btn(
+            QStyle.StandardPixmap.SP_MediaSkipForward,
+            "Force confirm all remaining quantity (qty > 5 only)",
+            28,
+        )
+        force_btn.setEnabled(required_qty > 5)
+        force_btn.clicked.connect(partial(self._on_force_confirm, row))
+        layout.addWidget(force_btn)
+
+        # Map SKU — shown only when SKU has no barcode mapping
+        norm_sku = self._normalize_sku(sku)
+        sku_is_mapped = norm_sku in set(sku_map.values())
+        if not sku_is_mapped:
+            map_btn = QPushButton("Map")
+            map_btn.setToolTip("Add barcode mapping for this SKU")
+            map_btn.setFixedWidth(40)
+            map_btn.setFocusPolicy(Qt.NoFocus)
+            map_btn.clicked.connect(partial(self._on_map_sku_requested, sku))
+            layout.addWidget(map_btn)
+
+        layout.addStretch()
+        return container
+
+    def _update_metadata_banner(self, metadata: Dict[str, Any] = None):
+        """Populate and show/hide the order metadata banner as chip labels."""
+        if not metadata:
+            self.metadata_banner.setVisible(False)
+            return
+
+        def _show_chip(lbl: QLabel, text: str):
+            if text:
+                lbl.setText(text)
+                lbl.setVisible(True)
+            else:
+                lbl.setText("")
+                lbl.setVisible(False)
+
+        order_type = metadata.get('order_type', '')
+        _show_chip(self._meta_type_lbl, f"Type: {order_type}" if order_type else "")
+
+        courier = metadata.get('shipping_provider', '')
+        _show_chip(self._meta_courier_lbl, f"Courier: {courier}" if courier else "")
+
+        country = metadata.get('destination_country', '')
+        _show_chip(self._meta_country_lbl, f"Dest: {country}" if country else "")
+
+        box = metadata.get('order_min_box', '')
+        _show_chip(self._meta_box_lbl, f"Box: {box}" if box else "")
+
+        all_tags = list(metadata.get('tags') or []) + list(metadata.get('internal_tags') or [])
+        tags_str = ", ".join(str(t) for t in all_tags if t is not None) if all_tags else ""
+        _show_chip(self._meta_tags_lbl, f"Tags: {tags_str}" if tags_str else "")
+
+        notes = metadata.get('notes') or metadata.get('system_note') or ''
+        _show_chip(self._meta_notes_lbl, str(notes) if notes else "")
+
+        has_anything = any([order_type, courier, country, box, tags_str, notes])
+        self.metadata_banner.setVisible(has_anything)
+
+    def _update_summary_panel(
+        self,
+        items: List[Dict[str, Any]],
+        order_state: List[Dict[str, Any]],
+    ):
+        """
+        Deduplicates items by SKU and updates the summary table with summed quantities.
+        This handles duplicate SKU rows that can appear in Shopify exports.
+        """
+        sku_totals: Dict[str, int] = defaultdict(int)
+        sku_packed: Dict[str, int] = defaultdict(int)
+
+        for item in items:
+            sku = item.get('SKU', item.get('sku', ''))
+            try:
+                qty = int(float(item.get('Quantity', item.get('quantity', 1))))
+            except (ValueError, TypeError):
+                qty = 1
+            sku_totals[sku] += qty
+
+        for state in order_state:
+            orig = state.get('original_sku', '')
+            sku_packed[orig] += state.get('packed', 0)
+
+        unique_skus = sorted(sku_totals.keys())
+        self.summary_table.setRowCount(len(unique_skus))
+
+        for i, sku in enumerate(unique_skus):
+            total = sku_totals[sku]
+            packed = sku_packed.get(sku, 0)
+            self.summary_table.setItem(i, 0, QTableWidgetItem(sku))
+            self.summary_table.setItem(i, 1, QTableWidgetItem(f"{packed} / {total}"))
+            status_text = "Done" if packed >= total else "Pending"
+            status_item = QTableWidgetItem(status_text)
+            if packed >= total:
+                status_item.setForeground(QColor("#43a047"))
+            self.summary_table.setItem(i, 2, status_item)
+
+        self.summary_frame.setVisible(len(unique_skus) > 0)
+
+    def _refresh_summary_from_table(self):
+        """
+        Rebuild the summary table by reading current row data directly from the
+        items table. Called from update_item_row() so the summary stays live.
+        Each table row has: col 1 = SKU, col 2 = "packed / total" text.
+        """
+        if not self.summary_frame.isVisible():
+            return
+
+        sku_packed: Dict[str, int] = defaultdict(int)
+        sku_totals: Dict[str, int] = defaultdict(int)
+
+        for r in range(self.table.rowCount()):
+            sku_item = self.table.item(r, 1)
+            qty_item  = self.table.item(r, 2)
+            if sku_item is None or qty_item is None:
+                continue
+            sku = sku_item.text()
+            parts = qty_item.text().split(' / ')
+            try:
+                packed = int(parts[0])
+                total  = int(parts[1]) if len(parts) > 1 else 1
+            except (ValueError, IndexError):
+                packed, total = 0, 1
+            sku_packed[sku] += packed
+            sku_totals[sku] += total
+
+        unique_skus = sorted(sku_totals.keys())
+        self.summary_table.setRowCount(len(unique_skus))
+        for i, sku in enumerate(unique_skus):
+            total  = sku_totals[sku]
+            packed = sku_packed.get(sku, 0)
+            self.summary_table.setItem(i, 0, QTableWidgetItem(sku))
+            self.summary_table.setItem(i, 1, QTableWidgetItem(f"{packed} / {total}"))
+            status_text = "Done" if packed >= total else "Pending"
+            status_item = QTableWidgetItem(status_text)
+            if packed >= total:
+                status_item.setForeground(QColor("#43a047"))
+            self.summary_table.setItem(i, 2, status_item)
+
+    @staticmethod
+    def _normalize_sku(sku: str) -> str:
+        """
+        Normalize a SKU string for comparison purposes (Map SKU detection only).
+        Matches the normalization used in PackerLogic._normalize_sku().
+        """
+        return ''.join(c for c in str(sku).lower() if c.isalnum() or c in '-_')

--- a/src/styles_dark.qss
+++ b/src/styles_dark.qss
@@ -298,6 +298,12 @@ QHeaderView::section:disabled {
     color: #444444;
 }
 
+/* Table corner button (top-left cell at row-header / column-header intersection) */
+QTableView QTableCornerButton::section {
+    background-color: #0a0a0a;
+    border: 1px solid #444444;
+}
+
 /* ----------------------------------------------------------------
    Table / Tree Views
    ---------------------------------------------------------------- */

--- a/src/styles_light.qss
+++ b/src/styles_light.qss
@@ -284,6 +284,12 @@ QHeaderView::section:hover {
     background-color: #d8e8f8;
 }
 
+/* Table corner button (top-left cell at row-header / column-header intersection) */
+QTableView QTableCornerButton::section {
+    background-color: #eeeeee;
+    border: 1px solid #cccccc;
+}
+
 /* ----------------------------------------------------------------
    Table / Tree Views
    ---------------------------------------------------------------- */


### PR DESCRIPTION
Logic (packer_logic.py):
- Store order-level metadata (type, courier, country, tags, notes, box) in orders_data alongside items; guard against null array fields
- Track extra items (over-scanned SKUs) in current_extra_items dict
- Track unknown/incorrect scans in unknown_scans list
- New signals: all_orders_complete
- New methods: cancel_item_scan, force_confirm_item, confirm_keep_extra, remove_extra_item, _maybe_complete_after_extra_resolution, _check_all_complete — fixes premature order completion when removing extras before all required items are scanned (Fix 5)
- Persist extras in session state file

Widget (packer_mode_widget.py):
- Session progress bar, metadata banner (chip-style per field + courier)
- Summary panel in right panel (expandable, live-updating during scan)
- Scanned Orders History moved to left panel below items table
- Extras panel with Keep/Remove per-SKU buttons
- Skip Order button
- Actions column uses Qt standard pixel-map icons (28px icon-only) instead of truncating text buttons; column narrowed to 135px
- Fix qty text color on completion (QColor() → palette Text role)
- _refresh_summary_from_table() called from update_item_row for live sync

Main (main.py):
- Connect 6 new widget signals; all_orders_complete in 3 start locations
- Map SKU: quick QInputDialog pre-labelled with SKU instead of full dialog
- Handle ORDER_COMPLETE_WITH_EXTRAS, SKU_EXTRA, EXTRA_CLEARED statuses
- Unknown scans: show running count + last barcode in notification
- _handle_order_completion() shared teardown method
- _on_all_orders_complete() end-session prompt

## Summary by Sourcery

Enhance packer mode to track order/session state more robustly, surface metadata and extras in the UI, and add controls for correcting scans and completing sessions safely.

New Features:
- Display order-level metadata, a live session progress bar, and a SKU summary panel in the packer mode UI.
- Support tracking and resolution of extra and unknown item scans, including an extras panel with keep/remove actions.
- Add quick in-session barcode-to-SKU mapping and a Skip Order action from the packer mode screen.
- Emit an all-orders-complete signal from packing logic to trigger an end-session prompt when all orders are packed.

Bug Fixes:
- Prevent premature order completion by requiring extra items to be explicitly resolved and rechecking that all required items are packed before finalizing an order.
- Fix quantity cell coloring on completion to avoid unreadable text on dark backgrounds.

Enhancements:
- Refine the packer mode layout by moving order history to the left, using icon-only action buttons, and adding per-SKU quantity highlighting.
- Persist extra-item state and richer order metadata in the session state for crash recovery and better restoration.
- Improve incorrect-scan feedback by tracking unknown scans and showing a running count with the last barcode in notifications.

Tests:
- Update packer mode widget tests to account for the new actions container in the table and the disabled state of the confirm button after completion.