### PR TITLE
perf: eliminate UI freezes — async state writer, background session I/O

### DIFF
--- a/src/async_state_writer.py
+++ b/src/async_state_writer.py
@@ -1,0 +1,125 @@
+"""
+Async write-behind queue for packing state files.
+
+Eliminates UI freezes caused by synchronous writes to a slow network share.
+The latest state is always kept in a single pending slot — never accumulates stale writes.
+"""
+
+import threading
+from typing import Callable, Dict, Any, Optional
+
+from logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class AsyncStateWriter:
+    """
+    Write-behind queue for state persistence.
+
+    Behaviour:
+    - schedule(state_dict): non-blocking, replaces any pending write
+    - flush(): blocking, waits until no pending write remains
+    - shutdown(): flush then stop daemon thread
+
+    Concurrency model:
+    - Only the caller (main/UI thread) calls schedule() and flush()
+    - Background daemon thread calls the write_fn
+    - state_dict must be a plain serialisable dict (snapshot, no shared objects)
+
+    sync_mode=True skips the background thread and writes synchronously;
+    useful for unit tests that assert file content after each call.
+    """
+
+    def __init__(
+        self,
+        write_fn: Callable[[Dict[str, Any]], None],
+        sync_mode: bool = False,
+    ) -> None:
+        self._write_fn = write_fn
+        self._sync_mode = sync_mode
+
+        if sync_mode:
+            return  # No thread needed
+
+        self._condition = threading.Condition()
+        self._pending: Optional[Dict[str, Any]] = None
+        self._stop = False
+        self._thread = threading.Thread(
+            target=self._run, daemon=True, name="state-writer"
+        )
+        self._thread.start()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def schedule(self, state_dict: Dict[str, Any]) -> None:
+        """
+        Non-blocking: schedule state_dict for writing.
+
+        If a previous write is still pending (not yet started), it is replaced
+        by this newer state — only the latest state ever reaches disk.
+        """
+        if self._sync_mode:
+            self._write_fn(state_dict)
+            return
+
+        with self._condition:
+            self._pending = state_dict
+            self._condition.notify()
+
+    def flush(self) -> None:
+        """
+        Blocking: wait until no pending write remains.
+
+        Call before checkpoints (order complete, session end) to guarantee
+        the latest state is on disk before proceeding.
+        """
+        if self._sync_mode:
+            return  # Already written synchronously
+
+        with self._condition:
+            while self._pending is not None:
+                self._condition.wait()
+
+    def shutdown(self) -> None:
+        """
+        Flush any pending write then stop the background thread.
+
+        Safe to call multiple times; subsequent calls are no-ops.
+        """
+        if self._sync_mode:
+            return
+
+        self.flush()
+        with self._condition:
+            self._stop = True
+            self._condition.notify()
+        self._thread.join(timeout=10)
+
+    # ------------------------------------------------------------------
+    # Background thread
+    # ------------------------------------------------------------------
+
+    def _run(self) -> None:
+        while True:
+            with self._condition:
+                # Wait until there is work to do or we should stop
+                while self._pending is None and not self._stop:
+                    self._condition.wait()
+
+                if self._stop and self._pending is None:
+                    break
+
+                state = self._pending
+                self._pending = None  # Claim the work
+
+            # Perform the write outside the lock so schedule() is never blocked
+            try:
+                self._write_fn(state)
+            except Exception:
+                logger.exception("AsyncStateWriter: write failed")
+            finally:
+                with self._condition:
+                    self._condition.notify_all()  # Wake flush() waiters

--- a/src/async_state_writer.py
+++ b/src/async_state_writer.py
@@ -5,6 +5,7 @@ Eliminates UI freezes caused by synchronous writes to a slow network share.
 The latest state is always kept in a single pending slot — never accumulates stale writes.
 """
 
+import copy
 import threading
 from typing import Callable, Dict, Any, Optional
 
@@ -19,13 +20,14 @@ class AsyncStateWriter:
 
     Behaviour:
     - schedule(state_dict): non-blocking, replaces any pending write
-    - flush(): blocking, waits until no pending write remains
+    - flush(): blocking, waits until the background thread has finished writing
     - shutdown(): flush then stop daemon thread
 
     Concurrency model:
-    - Only the caller (main/UI thread) calls schedule() and flush()
+    - schedule() and flush() must only be called from the main/UI thread
     - Background daemon thread calls the write_fn
-    - state_dict must be a plain serialisable dict (snapshot, no shared objects)
+    - Incoming state_dict is deep-copied on schedule() so the caller can freely
+      mutate its in-memory state immediately after scheduling
 
     sync_mode=True skips the background thread and writes synchronously;
     useful for unit tests that assert file content after each call.
@@ -44,6 +46,7 @@ class AsyncStateWriter:
 
         self._condition = threading.Condition()
         self._pending: Optional[Dict[str, Any]] = None
+        self._is_writing: bool = False  # True while write_fn is executing
         self._stop = False
         self._thread = threading.Thread(
             target=self._run, daemon=True, name="state-writer"
@@ -60,27 +63,33 @@ class AsyncStateWriter:
 
         If a previous write is still pending (not yet started), it is replaced
         by this newer state — only the latest state ever reaches disk.
+
+        A deep copy of state_dict is made immediately so the caller is free to
+        continue mutating its in-memory state without risking torn writes.
         """
         if self._sync_mode:
             self._write_fn(state_dict)
             return
 
+        snapshot = copy.deepcopy(state_dict)
         with self._condition:
-            self._pending = state_dict
+            self._pending = snapshot
             self._condition.notify()
 
     def flush(self) -> None:
         """
-        Blocking: wait until no pending write remains.
+        Blocking: wait until no pending write remains AND the current write (if
+        any) has completed.
 
         Call before checkpoints (order complete, session end) to guarantee
         the latest state is on disk before proceeding.
+        Must be called from the main/UI thread only.
         """
         if self._sync_mode:
             return  # Already written synchronously
 
         with self._condition:
-            while self._pending is not None:
+            while self._pending is not None or self._is_writing:
                 self._condition.wait()
 
     def shutdown(self) -> None:
@@ -113,7 +122,8 @@ class AsyncStateWriter:
                     break
 
                 state = self._pending
-                self._pending = None  # Claim the work
+                self._pending = None      # Claim the work
+                self._is_writing = True   # Signal that a write is in progress
 
             # Perform the write outside the lock so schedule() is never blocked
             try:
@@ -122,4 +132,5 @@ class AsyncStateWriter:
                 logger.exception("AsyncStateWriter: write failed")
             finally:
                 with self._condition:
+                    self._is_writing = False
                     self._condition.notify_all()  # Wake flush() waiters

--- a/tests/test_packer_logic.py
+++ b/tests/test_packer_logic.py
@@ -35,11 +35,15 @@ def test_dir():
 @pytest.fixture
 def packer_logic(mock_profile_manager, test_dir):
     """Create a PackerLogic instance with mocked ProfileManager."""
-    return PackerLogic(
+    logic = PackerLogic(
         client_id="TEST",
         profile_manager=mock_profile_manager,
         work_dir=test_dir
     )
+    yield logic
+    # Flush and shut down the async state writer so no background thread
+    # is still accessing test_dir when the temp dir is removed in teardown.
+    logic.close()
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes four freeze sources identified on the production file server:

1. **Scan freeze (5-10s each)** — `packing_state.json` now written by a background daemon thread (`AsyncStateWriter`).  `_save_session_state_async()` returns instantly on every scan; checkpoints (`ORDER_COMPLETE`, force-confirm, extra-resolution) use `_save_session_state_sync()` to flush before proceeding. `_save_session_state()` remains fully synchronous for backward-compat with tests.

2. **Session open freeze (20s)** — `SessionScanWorker(QThread)` scans session directories off the UI thread; dialog shows 'Loading…' and populates the list when done.  `analysis_data.json` reads switched to `get_cached_json()`. In pytest the scan runs synchronously (PYTEST_CURRENT_TEST guard).

3. **Session start/end freeze (20-30s each)** — `SessionStartWorker` and `SessionEndWorker` (QThread) run `load_packing_list_json` and `save_session_summary` + stats off the UI thread behind a `QProgressDialog` with a `processEvents` pump loop.

4. **Session Browser slow refresh (4-5 min)** — `RefreshWorker` now snapshots session-directory mtimes after each full scan (`save_session_dir_mtimes`). On subsequent refreshes it compares current mtimes; if nothing changed and cache is fresh it emits cached data immediately without reading any files.

## Summary by Sourcery

Eliminate UI freezes by moving slow session I/O and state persistence off the main thread and introducing caching-based fast paths for session browsing.

New Features:
- Add asynchronous state writer infrastructure to persist packing session state on a background thread with configurable sync behavior.
- Introduce background worker threads for session start and end workflows to keep the UI responsive behind progress dialogs.
- Add a background session-scan worker and cached session list filtering in the session selector dialog.
- Implement incremental refresh logic in the session browser using cached results and session-directory mtime snapshots.

Enhancements:
- Refactor session summary generation and stats recording to gather data on the main thread and perform disk writes in a background worker.
- Update session cleanup to shut down the async state writer instead of leaving it as a no-op.

Tests:
- Adjust PackerLogic test fixture to cleanly shut down the async state writer thread after each test.