### PR TITLE
fix: resolve session completion crashes and skip-order detection

### DIFF
--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -120,7 +120,8 @@ class PackerLogic(QObject):
         # This will be populated when loading an existing state or starting new
         self.session_packing_state = {
             'in_progress': {},
-            'completed_orders': []
+            'completed_orders': [],
+            'skipped_orders': [],
         }
 
         # Load SKU mapping from ProfileManager
@@ -400,6 +401,9 @@ class PackerLogic(QObject):
                 self.completed_orders_metadata = []
                 logger.debug("Old format: no timing metadata available")
 
+            # Load skipped orders list (added in later versions; default to empty list)
+            self.session_packing_state['skipped_orders'] = state_data.get('skipped_orders', [])
+
             # Load metadata if present (new format)
             if 'session_id' in state_data:
                 self.session_id = state_data.get('session_id')
@@ -501,6 +505,7 @@ class PackerLogic(QObject):
                 if hasattr(self, 'completed_orders_metadata') and self.completed_orders_metadata
                 else self._build_completed_list()
             ),
+            "skipped_orders": list(self.session_packing_state.get('skipped_orders', [])),
         }
 
     def _do_atomic_write(self, state_data: Dict[str, Any]) -> None:
@@ -570,6 +575,10 @@ class PackerLogic(QObject):
         self._state_writer.flush()
         self._state_writer.schedule(self._build_state_dict())
         self._state_writer.flush()  # Wait for the just-scheduled write to complete
+
+    def save_state(self) -> None:
+        """Public API: flush any pending async write and save current state synchronously."""
+        self._save_session_state_sync()
 
     def close(self) -> None:
         """
@@ -999,6 +1008,11 @@ class PackerLogic(QObject):
                 if self.current_order_number not in self.session_packing_state['completed_orders']:
                     self.session_packing_state['completed_orders'].append(self.current_order_number)
 
+                # Remove from skipped list if this order was previously skipped
+                skipped_list = self.session_packing_state.get('skipped_orders', [])
+                if self.current_order_number in skipped_list:
+                    skipped_list.remove(self.current_order_number)
+
                 # Emit session-complete signal if all orders done
                 self._check_all_complete()
             else:
@@ -1052,6 +1066,18 @@ class PackerLogic(QObject):
         self.current_extra_items = {}
         self.unknown_scans = []
 
+    def skip_order(self) -> None:
+        """Mark the current order as skipped, then check for overall session completion."""
+        if not self.current_order_number:
+            return
+        order_num = self.current_order_number
+        skipped = self.session_packing_state.setdefault('skipped_orders', [])
+        if order_num not in skipped:
+            skipped.append(order_num)
+        self.clear_current_order()
+        self._check_all_complete()
+        self._save_session_state_async()
+
     def cancel_item_scan(self, row: int) -> Tuple[Dict, str]:
         """
         Decrements the packed count for the item at the given row by 1.
@@ -1100,6 +1126,9 @@ class PackerLogic(QObject):
             del self.session_packing_state['in_progress'][self.current_order_number]
             if self.current_order_number not in self.session_packing_state['completed_orders']:
                 self.session_packing_state['completed_orders'].append(self.current_order_number)
+            skipped_list = self.session_packing_state.get('skipped_orders', [])
+            if self.current_order_number in skipped_list:
+                skipped_list.remove(self.current_order_number)
             self._check_all_complete()
             self._save_session_state_sync()  # Checkpoint: order now complete
         else:
@@ -1112,10 +1141,11 @@ class PackerLogic(QObject):
         }, "FORCE_CONFIRMED"
 
     def _check_all_complete(self):
-        """Emit all_orders_complete if every order in the session is packed."""
+        """Emit all_orders_complete if every order in the session is packed or skipped."""
         total = len(self.orders_data)
         done = len(self.session_packing_state.get('completed_orders', []))
-        if total > 0 and done >= total:
+        skipped = len(self.session_packing_state.get('skipped_orders', []))
+        if total > 0 and (done + skipped) >= total:
             self.all_orders_complete.emit()
 
     def confirm_keep_extra(self, normalized_sku: str) -> Tuple[Dict, str]:
@@ -1162,6 +1192,9 @@ class PackerLogic(QObject):
         del self.session_packing_state['in_progress'][self.current_order_number]
         if self.current_order_number not in self.session_packing_state['completed_orders']:
             self.session_packing_state['completed_orders'].append(self.current_order_number)
+        skipped_list = self.session_packing_state.get('skipped_orders', [])
+        if self.current_order_number in skipped_list:
+            skipped_list.remove(self.current_order_number)
         self._check_all_complete()
         self._save_session_state_sync()  # Checkpoint: order now complete
         return {}, "ORDER_NOW_COMPLETE"

--- a/tests/test_state_persistence.py
+++ b/tests/test_state_persistence.py
@@ -581,7 +581,7 @@ class TestCrashRecovery(unittest.TestCase):
         packer = PackerLogic("TEST", self.mock_profile_manager, str(self.work_dir))
 
         # Verify it starts with fresh state
-        self.assertEqual(packer.session_packing_state, {'in_progress': {}, 'completed_orders': []})
+        self.assertEqual(packer.session_packing_state, {'in_progress': {}, 'completed_orders': [], 'skipped_orders': []})
         self.assertIsNone(packer.session_id)
 
     def test_state_metadata_complete(self):


### PR DESCRIPTION
- Add public save_state() to PackerLogic so closeEvent no longer calls a non-existent method (silent AttributeError was dropping state on window close)
- Track skipped_orders in session_packing_state; _check_all_complete() now counts done + skipped >= total, so the "end session" dialog fires correctly even when orders were skipped
- Add skip_order() method to PackerLogic; _on_skip_order in main.py calls it instead of clear_current_order(), enabling completion check after each skip
- Remove order from skipped_orders if later packed (all 3 completion paths: process_sku_scan, force_confirm_item, extra resolution)
- Persist and reload skipped_orders via _build_state_dict / _load_session_state for crash-safe resumability
- Show skipped count in session-complete dialog message
- end_session() now switches stacked widget back to session_widget so the user is not left on a blank packer mode screen

## Summary by Sourcery

Track skipped orders in packing sessions, persist their state, and ensure session completion and UI flows behave correctly when orders are skipped or the app is closed.

New Features:
- Support marking orders as skipped within a packing session and include skipped orders in overall session completion logic.

Bug Fixes:
- Prevent state loss on window close by exposing a public save_state API and using it instead of a non-existent method.
- Ensure the session-complete dialog appears even when some orders are skipped rather than packed.
- Return the UI to the session view on session end instead of leaving the user on an empty packer screen.

Enhancements:
- Persist and reload skipped orders as part of the session state for crash-safe resumability and cleanup skipped status when an order is later completed.
- Update the session completion dialog to report the number of skipped orders and use session-complete messaging rather than only 'all packed'.