### PR TITLE
feat: comprehensive scan metrics overhaul with quality tracking (v1.3…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2137,11 +2137,18 @@ class MainWindow(QMainWindow):
         result, status = self.logic.force_confirm_item(row)
         if status == "FORCE_CONFIRMED":
             self.packer_mode_widget.update_item_row(row, result["packed"], True)
-            self.flash_border("green")
             if result.get("order_complete"):
+                self.flash_border("green")
                 order_num = self.logic.current_order_number
                 self._handle_order_completion(order_num)
                 self.logic.clear_current_order()
+            elif self.logic.current_extra_items:
+                # All items packed but extra items need resolution before completing
+                self.flash_border("orange")
+                self.packer_mode_widget.show_notification("REVIEW EXTRA ITEMS!", "#e67e22")
+                self.packer_mode_widget.show_extras_panel(self.logic.current_extra_items)
+            else:
+                self.flash_border("green")
         self.packer_mode_widget.set_focus_to_scanner()
 
     def _on_map_sku_from_packer(self, sku: str):

--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -122,12 +122,23 @@ class PackerLogic(QObject):
             'in_progress': {},
             'completed_orders': [],
             'skipped_orders': [],
+            'skipped_orders_timing': {},  # order_num -> ISO timestamp of skip
         }
+
+        # Phase 2b: Order-level timing tracking — initialized BEFORE _load_session_state()
+        # so that _load_session_state() can populate them from disk without being overwritten.
+        self.current_order_start_time = None  # ISO timestamp when order scanning started
+        self.current_order_items_scanned = []  # List of items with scan timestamps
+        self.completed_orders_metadata = []  # List of completed orders with timing data
+
+        # Per-order counters for 1.7 metrics — reset by start_order_packing()
+        self.current_order_corrections: int = 0       # cancel_item_scan() events
+        self.current_order_extra_scan_count: int = 0  # SKU_EXTRA events
 
         # Load SKU mapping from ProfileManager
         self.sku_map = self._load_sku_mapping()
 
-        # Load session state if exists
+        # Load session state if exists (must come AFTER Phase 2b vars are declared)
         self._load_session_state()
 
         # Extra items tracking: normalized_sku → extra count (scanned beyond required)
@@ -135,11 +146,6 @@ class PackerLogic(QObject):
 
         # Unknown/incorrect scan tracking: raw barcodes that didn't match any SKU
         self.unknown_scans: List[str] = []
-
-        # Phase 2b: Order-level timing tracking
-        self.current_order_start_time = None  # ISO timestamp when order scanning started
-        self.current_order_items_scanned = []  # List of items with scan timestamps
-        self.completed_orders_metadata = []  # List of completed orders with timing data
 
         # Write-behind queue: state writes happen in background to avoid UI freezes.
         # sync_mode=True is used in tests to keep writes synchronous.
@@ -150,7 +156,7 @@ class PackerLogic(QObject):
         logger.debug(f"Barcode directory: {self.barcode_dir}")
         logger.debug(f"Reports directory: {self.reports_dir}")
         logger.debug(f"Loaded {len(self.sku_map)} SKU mappings")
-        logger.debug("Phase 2b timing variables initialized")
+        logger.debug("Phase 2b timing variables initialized (loaded from state if available)")
 
     def _load_sku_mapping(self) -> Dict[str, str]:
         """
@@ -262,7 +268,7 @@ class PackerLogic(QObject):
 
         if not os.path.exists(state_file):
             logger.debug("No existing session state found, starting fresh")
-            self.session_packing_state = {'in_progress': {}, 'completed_orders': [], 'skipped_orders': []}
+            self.session_packing_state = {'in_progress': {}, 'completed_orders': [], 'skipped_orders': [], 'skipped_orders_timing': {}}
             return
 
         try:
@@ -274,7 +280,7 @@ class PackerLogic(QObject):
             if data is None:
                 # File exists but couldn't be read (invalid JSON, etc.)
                 logger.error("Could not load session state, starting fresh")
-                self.session_packing_state = {'in_progress': {}, 'completed_orders': [], 'skipped_orders': []}
+                self.session_packing_state = {'in_progress': {}, 'completed_orders': [], 'skipped_orders': [], 'skipped_orders_timing': {}}
                 return
 
             # Handle both old and new format (with version)
@@ -403,6 +409,8 @@ class PackerLogic(QObject):
 
             # Load skipped orders list (added in later versions; default to empty list)
             self.session_packing_state['skipped_orders'] = state_data.get('skipped_orders', [])
+            # Load skipped orders timing (maps order_num -> ISO skip timestamp)
+            self.session_packing_state['skipped_orders_timing'] = state_data.get('skipped_orders_timing', {})
 
             # Load metadata if present (new format)
             if 'session_id' in state_data:
@@ -432,7 +440,7 @@ class PackerLogic(QObject):
 
         except (json.JSONDecodeError, IOError) as e:
             logger.error(f"Error loading session state: {e}, starting fresh")
-            self.session_packing_state = {'in_progress': {}, 'completed_orders': [], 'skipped_orders': []}
+            self.session_packing_state = {'in_progress': {}, 'completed_orders': [], 'skipped_orders': [], 'skipped_orders_timing': {}}
 
     def _build_state_dict(self) -> Dict[str, Any]:
         """
@@ -506,6 +514,7 @@ class PackerLogic(QObject):
                 else self._build_completed_list()
             ),
             "skipped_orders": list(self.session_packing_state.get('skipped_orders', [])),
+            "skipped_orders_timing": dict(self.session_packing_state.get('skipped_orders_timing', {})),
         }
 
     def _do_atomic_write(self, state_data: Dict[str, Any]) -> None:
@@ -606,21 +615,21 @@ class PackerLogic(QObject):
         Note: This is a basic implementation. Full timestamps tracking requires
         storing start time for each order (future enhancement).
         """
+        from shared.metadata_utils import get_current_timestamp
+        # Single approximate timestamp for the whole fallback list (not per-order)
+        fallback_ts = get_current_timestamp()
         completed_list = []
 
         for order_number in self.session_packing_state.get('completed_orders', []):
-            # Get items count for this order
             items_count = 0
             if order_number in self.orders_data:
                 items_count = len(self.orders_data[order_number].get('items', []))
 
-            from shared.metadata_utils import get_current_timestamp
-
             completed_list.append({
                 "order_number": order_number,
-                "completed_at": get_current_timestamp(),  # Approximation
-                "items_count": items_count
-                # duration_seconds: Cannot calculate without start time (future enhancement)
+                "completed_at": fallback_ts,  # Approximation — no per-order timestamps available
+                "items_count": items_count,
+                # duration_seconds omitted: no start time available in fallback path
             })
 
         return completed_list
@@ -652,22 +661,38 @@ class PackerLogic(QObject):
             duration_seconds = 0
             logger.warning(f"Order {self.current_order_number} has no start time")
 
-        # Build order metadata record
+        # Extract first-scan latency from scan records (if any)
+        time_to_first_scan = None
+        for record in self.current_order_items_scanned:
+            if "time_to_first_scan_seconds" in record:
+                time_to_first_scan = record["time_to_first_scan_seconds"]
+                break
+
+        # Build order metadata record with full 1.7 metrics
         order_metadata = {
             "order_number": self.current_order_number,
             "started_at": self.current_order_start_time,
             "completed_at": completed_at,
             "duration_seconds": duration_seconds,
             "items_count": len(self.current_order_items_scanned),
-            "items": self.current_order_items_scanned.copy()  # Full items with timestamps
+            "items": self.current_order_items_scanned.copy(),
+            # 1.7 per-order counters
+            "corrections": self.current_order_corrections,
+            "extra_scans_count": self.current_order_extra_scan_count,
+            "unknown_scans_count": len(self.unknown_scans),
         }
+        if time_to_first_scan is not None:
+            order_metadata["time_to_first_scan_seconds"] = time_to_first_scan
 
         # Add to completed orders metadata
         self.completed_orders_metadata.append(order_metadata)
 
         logger.info(
             f"Order {self.current_order_number} completed: "
-            f"duration={duration_seconds}s, items={len(self.current_order_items_scanned)}"
+            f"duration={duration_seconds}s, items={len(self.current_order_items_scanned)}, "
+            f"corrections={self.current_order_corrections}, "
+            f"extras={self.current_order_extra_scan_count}, "
+            f"unknown={len(self.unknown_scans)}"
         )
 
         # Note: We don't reset current_order_number here because it's still needed
@@ -816,7 +841,10 @@ class PackerLogic(QObject):
         self.current_order_number = original_order_number
         items = self.orders_data[original_order_number]['items']
 
-        if original_order_number in self.session_packing_state['in_progress']:
+        # Capture "is this a brand-new order?" BEFORE potentially adding it to in_progress.
+        is_new_order = original_order_number not in self.session_packing_state['in_progress']
+
+        if not is_new_order:
             self.current_order_state = self.session_packing_state['in_progress'][original_order_number]
         else:
             self.current_order_state = []
@@ -839,12 +867,31 @@ class PackerLogic(QObject):
             self.session_packing_state['in_progress'][original_order_number] = self.current_order_state
             self._save_session_state_async()
 
-        # Phase 2b: Record order start time
+        # Phase 2b: Record order start time.
+        # Only reset timing for brand-new orders. For orders already in in_progress (resumed
+        # from a previous session), preserve the start time and scanned items list that were
+        # restored by _load_session_state() so timing continuity is maintained.
         from shared.metadata_utils import get_current_timestamp
-        self.current_order_start_time = get_current_timestamp()
-        self.current_order_items_scanned = []
-
-        logger.info(f"Order {original_order_number} started at {self.current_order_start_time}")
+        if is_new_order:
+            self.current_order_start_time = get_current_timestamp()
+            self.current_order_items_scanned = []
+            self.current_order_corrections = 0
+            self.current_order_extra_scan_count = 0
+            logger.info(f"Order {original_order_number} started at {self.current_order_start_time}")
+        else:
+            # Resumed order — keep existing timing from loaded state.
+            # If start time is missing despite being in in_progress, fall back gracefully.
+            if not self.current_order_start_time:
+                self.current_order_start_time = get_current_timestamp()
+                logger.warning(
+                    f"Order {original_order_number} resumed but had no start time; "
+                    "resetting to now"
+                )
+            logger.info(
+                f"Order {original_order_number} resumed; "
+                f"preserving start_time={self.current_order_start_time}, "
+                f"{len(self.current_order_items_scanned)} items already scanned"
+            )
 
         return items, "ORDER_LOADED"
 
@@ -962,14 +1009,22 @@ class PackerLogic(QObject):
             items_list = self.orders_data[self.current_order_number]['items']
             item_idx = found_item['row']
 
+            # Record first-scan latency (time between order start and very first item scan)
+            time_to_first_scan = (
+                time_from_order_start if len(self.current_order_items_scanned) == 0 else None
+            )
+
             # Build item scan record
             item_scan_record = {
                 "sku": normalized_final_sku,
                 "title": items_list[item_idx].get('Product_Name', normalized_final_sku),
                 "quantity": found_item['required'],
                 "scanned_at": scan_timestamp,
-                "time_from_order_start_seconds": time_from_order_start
+                "time_from_order_start_seconds": time_from_order_start,
+                "confirmation_method": "scanned",
             }
+            if time_to_first_scan is not None:
+                item_scan_record["time_to_first_scan_seconds"] = time_to_first_scan
 
             # Add to scanned items list
             self.current_order_items_scanned.append(item_scan_record)
@@ -1049,6 +1104,7 @@ class PackerLogic(QObject):
             self.current_extra_items[normalized_final_sku] = (
                 self.current_extra_items.get(normalized_final_sku, 0) + 1
             )
+            self.current_order_extra_scan_count += 1
             self._save_session_state_async()
             return None, "SKU_EXTRA"
         else:
@@ -1068,10 +1124,13 @@ class PackerLogic(QObject):
         """Mark the current order as skipped, then check for overall session completion."""
         if not self.current_order_number:
             return
+        from shared.metadata_utils import get_current_timestamp
         order_num = self.current_order_number
         skipped = self.session_packing_state['skipped_orders']
         if order_num not in skipped:
             skipped.append(order_num)
+        # Record the skip timestamp for metrics
+        self.session_packing_state['skipped_orders_timing'][order_num] = get_current_timestamp()
         self.clear_current_order()
         self._check_all_complete()
         self._save_session_state_async()
@@ -1101,6 +1160,17 @@ class PackerLogic(QObject):
         if item['packed'] <= 0:
             return {"row": row, "packed": 0}, "ITEM_ALREADY_ZERO"
         item['packed'] -= 1
+        self.current_order_corrections += 1
+
+        # Remove the most recent scan record for this item from the scan history so
+        # that items_count in the completed-order metadata reflects only final packed
+        # quantities (not cancelled intermediate scans).
+        normalized_sku = item.get('normalized_sku', '')
+        for i in range(len(self.current_order_items_scanned) - 1, -1, -1):
+            if self.current_order_items_scanned[i].get('sku') == normalized_sku:
+                self.current_order_items_scanned.pop(i)
+                break
+
         self.session_packing_state['in_progress'][self.current_order_number] = self.current_order_state
         self._save_session_state_async()
         return {"row": row, "packed": item['packed']}, "ITEM_DECREMENTED"
@@ -1122,6 +1192,29 @@ class PackerLogic(QObject):
         item = next((s for s in self.current_order_state if s.get('row') == row), None)
         if item is None:
             return {}, "NO_ACTIVE_ORDER"
+
+        # Add a scan record for the force-confirmed quantity (remaining unpacked qty).
+        # This ensures _complete_current_order() sees a full items list with timestamps.
+        from shared.metadata_utils import get_current_timestamp, calculate_duration
+        force_timestamp = get_current_timestamp()
+        time_from_start = (
+            calculate_duration(self.current_order_start_time, force_timestamp)
+            if self.current_order_start_time else 0
+        )
+        items_list = self.orders_data[self.current_order_number]['items']
+        item_idx = item.get('row', 0)
+        force_record = {
+            "sku": item['normalized_sku'],
+            "title": items_list[item_idx].get('Product_Name', item['normalized_sku']) if item_idx < len(items_list) else item['normalized_sku'],
+            "quantity": item['required'],
+            "scanned_at": force_timestamp,
+            "time_from_order_start_seconds": time_from_start,
+            "confirmation_method": "force_confirmed",
+        }
+        # Only add record if the item wasn't already fully scanned (avoids duplicates)
+        if item['packed'] < item['required']:
+            self.current_order_items_scanned.append(force_record)
+
         item['packed'] = item['required']
         self.session_packing_state['in_progress'][self.current_order_number] = self.current_order_state
         all_done = all(s['packed'] >= s['required'] for s in self.current_order_state)
@@ -1650,70 +1743,75 @@ class PackerLogic(QObject):
         # Count unique SKUs
         unique_skus = self._count_unique_skus()
 
-        # Phase 2b: Calculate metrics from completed_orders_metadata
-        if hasattr(self, 'completed_orders_metadata') and self.completed_orders_metadata:
-            orders_with_timing = self.completed_orders_metadata
+        # Calculate metrics from completed_orders_metadata
+        orders_with_timing = self.completed_orders_metadata if self.completed_orders_metadata else []
 
-            # Extract durations
-            durations = [
-                order['duration_seconds']
-                for order in orders_with_timing
-                if order.get('duration_seconds')
-            ]
-
-            # Calculate order-level metrics
-            if durations:
-                avg_time_per_order = round(sum(durations) / len(durations), 1)
-                fastest_order_seconds = min(durations)
-                slowest_order_seconds = max(durations)
-            else:
-                avg_time_per_order = 0
-                fastest_order_seconds = 0
-                slowest_order_seconds = 0
-
-            # Calculate item-level metrics
-            all_items = []
-            for order in orders_with_timing:
-                all_items.extend(order.get('items', []))
-
-            if all_items:
-                item_times = [
-                    item['time_from_order_start_seconds']
-                    for item in all_items
-                    if 'time_from_order_start_seconds' in item
-                ]
-                avg_time_per_item = round(sum(item_times) / len(item_times), 1) if item_times else 0
-            else:
-                avg_time_per_item = 0
-
-            # Total items from metadata
-            total_items_from_metadata = sum(order.get('items_count', 0) for order in orders_with_timing)
-
+        # --- Order-level timing ---
+        durations = [o['duration_seconds'] for o in orders_with_timing if o.get('duration_seconds')]
+        if durations:
+            avg_time_per_order = round(sum(durations) / len(durations), 1)
+            fastest_order_seconds = min(durations)
+            slowest_order_seconds = max(durations)
         else:
-            # Fallback for old sessions without timing
-            logger.warning("No timing metadata available, using fallback calculations")
             avg_time_per_order = 0
-            avg_time_per_item = 0
             fastest_order_seconds = 0
             slowest_order_seconds = 0
-            total_items_from_metadata = 0
 
-        # Session-level performance (orders_per_hour, items_per_hour)
+        # --- Item-level timing ---
+        all_items = []
+        for order in orders_with_timing:
+            all_items.extend(order.get('items', []))
+
+        item_times = [
+            item['time_from_order_start_seconds']
+            for item in all_items
+            if 'time_from_order_start_seconds' in item
+        ]
+        avg_time_per_item = round(sum(item_times) / len(item_times), 1) if item_times else 0
+
+        total_items_from_metadata = sum(o.get('items_count', 0) for o in orders_with_timing)
+
+        # --- 1.7 metrics: first-scan latency ---
+        first_scan_latencies = [
+            o['time_to_first_scan_seconds']
+            for o in orders_with_timing
+            if o.get('time_to_first_scan_seconds') is not None
+        ]
+        avg_time_to_first_scan = (
+            round(sum(first_scan_latencies) / len(first_scan_latencies), 1)
+            if first_scan_latencies else 0
+        )
+
+        # --- 1.7 metrics: corrections, extras, unknown scans ---
+        total_corrections = sum(o.get('corrections', 0) for o in orders_with_timing)
+        total_extra_scans = sum(o.get('extra_scans_count', 0) for o in orders_with_timing)
+        total_unknown_scans = sum(o.get('unknown_scans_count', 0) for o in orders_with_timing)
+        avg_corrections_per_order = (
+            round(total_corrections / len(orders_with_timing), 2) if orders_with_timing else 0
+        )
+
+        if not orders_with_timing:
+            logger.warning("No timing metadata available, metrics will be zero")
+
+        # --- Session-level throughput ---
         orders_per_hour = 0
         items_per_hour = 0
-
         if duration_seconds and duration_seconds > 0:
             hours = duration_seconds / 3600.0
-
             if completed_orders > 0:
                 orders_per_hour = round(completed_orders / hours, 1)
-
-            # Use metadata total_items if available, otherwise fallback to processed_df total
             items_for_rate = total_items_from_metadata if total_items_from_metadata > 0 else total_items
             if items_for_rate > 0:
                 items_per_hour = round(items_for_rate / hours, 1)
 
-        # Build unified v1.3.0 session summary
+        # --- Skipped orders list for the summary ---
+        skipped_timing = self.session_packing_state.get('skipped_orders_timing', {})
+        skipped_orders_list = [
+            {"order_number": num, "skipped_at": skipped_timing.get(num), "status": "skipped"}
+            for num in self.session_packing_state.get('skipped_orders', [])
+        ]
+
+        # Build unified session summary
         summary = {
             # Metadata
             "version": "1.3.0",
@@ -1735,6 +1833,8 @@ class PackerLogic(QObject):
             # Counts
             "total_orders": total_orders,
             "completed_orders": completed_orders,
+            "in_progress_orders": len(self.session_packing_state.get('in_progress', {})),
+            "skipped_orders_count": len(skipped_orders_list),
             "total_items": total_items,
             "unique_skus": unique_skus,
 
@@ -1742,19 +1842,28 @@ class PackerLogic(QObject):
             "metrics": {
                 "avg_time_per_order": avg_time_per_order,
                 "avg_time_per_item": avg_time_per_item,
-                "fastest_order_seconds": fastest_order_seconds,  # Phase 2b: Real data from timing
-                "slowest_order_seconds": slowest_order_seconds,   # Phase 2b: Real data from timing
+                "fastest_order_seconds": fastest_order_seconds,
+                "slowest_order_seconds": slowest_order_seconds,
                 "orders_per_hour": orders_per_hour,
-                "items_per_hour": items_per_hour
+                "items_per_hour": items_per_hour,
+                # 1.7 metrics
+                "avg_time_to_first_scan": avg_time_to_first_scan,
+                "total_corrections": total_corrections,
+                "avg_corrections_per_order": avg_corrections_per_order,
+                "total_extra_scans": total_extra_scans,
+                "total_unknown_scans": total_unknown_scans,
             },
 
-            # Phase 2b: Populate orders array with timing data
-            "orders": self.completed_orders_metadata if hasattr(self, 'completed_orders_metadata') else []
+            # Completed orders with full timing data
+            "orders": orders_with_timing,
+
+            # Skipped orders list
+            "skipped_orders": skipped_orders_list,
         }
 
         logger.info(
-            f"Session summary generated (v1.3.0): {completed_orders}/{total_orders} orders, "
-            f"{total_items} items, {unique_skus} unique SKUs, "
+            f"Session summary generated: {completed_orders}/{total_orders} orders, "
+            f"{len(skipped_orders_list)} skipped, {total_items} items, "
             f"{duration_seconds}s duration, {orders_per_hour} orders/hour"
         )
 

--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -392,7 +392,13 @@ class PackerLogic(QObject):
                             'completed_at': item.get('completed_at'),
                             'duration_seconds': item.get('duration_seconds', 0),
                             'items_count': item.get('items_count', 0),
-                            'items': item.get('items', [])
+                            'items': item.get('items', []),
+                            # Restore 1.7 quality counters so generate_session_summary()
+                            # aggregates correctly across resumed sessions.
+                            'corrections': item.get('corrections', 0),
+                            'extra_scans_count': item.get('extra_scans_count', 0),
+                            'unknown_scans_count': item.get('unknown_scans_count', 0),
+                            'time_to_first_scan_seconds': item.get('time_to_first_scan_seconds'),
                         }
                         self.completed_orders_metadata.append(metadata)
 
@@ -426,10 +432,16 @@ class PackerLogic(QObject):
                 timing_data = state_data['in_progress']['_timing']
                 self.current_order_start_time = timing_data.get('current_order_start_time')
                 self.current_order_items_scanned = timing_data.get('items_scanned', [])
+                self.current_order_corrections = timing_data.get('corrections', 0)
+                self.current_order_extra_scan_count = timing_data.get('extra_scan_count', 0)
+                self.current_order_unknown_scan_count = timing_data.get('unknown_scan_count', 0)
                 logger.debug(f"Restored in-progress timing: started_at={self.current_order_start_time}")
             else:
                 self.current_order_start_time = None
                 self.current_order_items_scanned = []
+                self.current_order_corrections = 0
+                self.current_order_extra_scan_count = 0
+                self.current_order_unknown_scan_count = 0
 
             # Restore extra items if present (crash recovery)
             self.current_extra_items = state_data.get('_current_extras', {})
@@ -504,7 +516,10 @@ class PackerLogic(QObject):
                 **({
                     "_timing": {
                         "current_order_start_time": self.current_order_start_time,
-                        "items_scanned": self.current_order_items_scanned
+                        "items_scanned": self.current_order_items_scanned,
+                        "corrections": self.current_order_corrections,
+                        "extra_scan_count": self.current_order_extra_scan_count,
+                        "unknown_scan_count": self.current_order_unknown_scan_count,
                     }
                 } if self.current_order_number and self.current_order_start_time else {})
             },
@@ -886,11 +901,8 @@ class PackerLogic(QObject):
             self.current_order_unknown_scan_count = 0
             logger.info(f"Order {original_order_number} started at {self.current_order_start_time}")
         else:
-            # Resumed order — keep existing timing from loaded state, but reset per-order
-            # quality counters since they cannot be restored from packing_state.json.
-            self.current_order_corrections = 0
-            self.current_order_extra_scan_count = 0
-            self.current_order_unknown_scan_count = 0
+            # Resumed order — all timing and per-order quality counters were restored from
+            # _timing in _load_session_state(); nothing to reset here.
             # If start time is missing despite being in in_progress, fall back gracefully.
             if not self.current_order_start_time:
                 self.current_order_start_time = get_current_timestamp()
@@ -1025,7 +1037,10 @@ class PackerLogic(QObject):
                 time_from_order_start if len(self.current_order_items_scanned) == 0 else None
             )
 
-            # Build item scan record — quantity=1: each scan packs exactly one unit
+            # Build item scan record — quantity=1: each scan packs exactly one unit.
+            # "row" is stored so cancel_item_scan() can target the correct record
+            # by row index rather than by SKU (which is ambiguous when multiple
+            # rows share the same SKU, e.g. split-line orders).
             item_title = (
                 items_list[item_idx].get('Product_Name', normalized_final_sku)
                 if item_idx < len(items_list)
@@ -1035,6 +1050,7 @@ class PackerLogic(QObject):
                 "sku": normalized_final_sku,
                 "title": item_title,
                 "quantity": 1,
+                "row": item_idx,
                 "scanned_at": scan_timestamp,
                 "time_from_order_start_seconds": time_from_order_start,
                 "confirmation_method": "scanned",
@@ -1181,13 +1197,15 @@ class PackerLogic(QObject):
 
         # Adjust the most recent scan record for this item so that items_count in the
         # completed-order metadata reflects only the final packed quantity.
+        # Match by row (precise) so that cancelling row N never accidentally modifies a
+        # record belonging to a different row that happens to share the same SKU.
         # Records with quantity > 1 (e.g. a force-confirm record) are decremented rather
-        # than deleted, since only one unit is being cancelled.
-        normalized_sku = item.get('normalized_sku', '')
+        # than deleted, since only one unit is being cancelled at a time.
         for i in range(len(self.current_order_items_scanned) - 1, -1, -1):
-            if self.current_order_items_scanned[i].get('sku') == normalized_sku:
-                if self.current_order_items_scanned[i].get('quantity', 1) > 1:
-                    self.current_order_items_scanned[i]['quantity'] -= 1
+            rec = self.current_order_items_scanned[i]
+            if rec.get('row') == row:
+                if rec.get('quantity', 1) > 1:
+                    rec['quantity'] -= 1
                 else:
                     self.current_order_items_scanned.pop(i)
                 break
@@ -1235,6 +1253,7 @@ class PackerLogic(QObject):
             "sku": item['normalized_sku'],
             "title": item_title,
             "quantity": remaining_qty,
+            "row": item_idx,
             "scanned_at": force_timestamp,
             "time_from_order_start_seconds": time_from_start,
             "confirmation_method": "force_confirmed",

--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -132,8 +132,9 @@ class PackerLogic(QObject):
         self.completed_orders_metadata = []  # List of completed orders with timing data
 
         # Per-order counters for 1.7 metrics — reset by start_order_packing()
-        self.current_order_corrections: int = 0       # cancel_item_scan() events
-        self.current_order_extra_scan_count: int = 0  # SKU_EXTRA events
+        self.current_order_corrections: int = 0           # cancel_item_scan() events
+        self.current_order_extra_scan_count: int = 0      # SKU_EXTRA events
+        self.current_order_unknown_scan_count: int = 0    # SKU_NOT_FOUND events
 
         # Load SKU mapping from ProfileManager
         self.sku_map = self._load_sku_mapping()
@@ -668,18 +669,23 @@ class PackerLogic(QObject):
                 time_to_first_scan = record["time_to_first_scan_seconds"]
                 break
 
+        # items_count = total units packed (sum of quantities across all scan records).
+        # Using sum() rather than len() correctly accounts for force-confirm records
+        # that represent multiple units in a single record entry.
+        items_count = sum(r.get('quantity', 1) for r in self.current_order_items_scanned)
+
         # Build order metadata record with full 1.7 metrics
         order_metadata = {
             "order_number": self.current_order_number,
             "started_at": self.current_order_start_time,
             "completed_at": completed_at,
             "duration_seconds": duration_seconds,
-            "items_count": len(self.current_order_items_scanned),
+            "items_count": items_count,
             "items": self.current_order_items_scanned.copy(),
             # 1.7 per-order counters
             "corrections": self.current_order_corrections,
             "extra_scans_count": self.current_order_extra_scan_count,
-            "unknown_scans_count": len(self.unknown_scans),
+            "unknown_scans_count": self.current_order_unknown_scan_count,
         }
         if time_to_first_scan is not None:
             order_metadata["time_to_first_scan_seconds"] = time_to_first_scan
@@ -689,10 +695,10 @@ class PackerLogic(QObject):
 
         logger.info(
             f"Order {self.current_order_number} completed: "
-            f"duration={duration_seconds}s, items={len(self.current_order_items_scanned)}, "
+            f"duration={duration_seconds}s, items={items_count}, "
             f"corrections={self.current_order_corrections}, "
             f"extras={self.current_order_extra_scan_count}, "
-            f"unknown={len(self.unknown_scans)}"
+            f"unknown={self.current_order_unknown_scan_count}"
         )
 
         # Note: We don't reset current_order_number here because it's still needed
@@ -877,9 +883,14 @@ class PackerLogic(QObject):
             self.current_order_items_scanned = []
             self.current_order_corrections = 0
             self.current_order_extra_scan_count = 0
+            self.current_order_unknown_scan_count = 0
             logger.info(f"Order {original_order_number} started at {self.current_order_start_time}")
         else:
-            # Resumed order — keep existing timing from loaded state.
+            # Resumed order — keep existing timing from loaded state, but reset per-order
+            # quality counters since they cannot be restored from packing_state.json.
+            self.current_order_corrections = 0
+            self.current_order_extra_scan_count = 0
+            self.current_order_unknown_scan_count = 0
             # If start time is missing despite being in in_progress, fall back gracefully.
             if not self.current_order_start_time:
                 self.current_order_start_time = get_current_timestamp()
@@ -1014,11 +1025,16 @@ class PackerLogic(QObject):
                 time_from_order_start if len(self.current_order_items_scanned) == 0 else None
             )
 
-            # Build item scan record
+            # Build item scan record — quantity=1: each scan packs exactly one unit
+            item_title = (
+                items_list[item_idx].get('Product_Name', normalized_final_sku)
+                if item_idx < len(items_list)
+                else normalized_final_sku
+            )
             item_scan_record = {
                 "sku": normalized_final_sku,
-                "title": items_list[item_idx].get('Product_Name', normalized_final_sku),
-                "quantity": found_item['required'],
+                "title": item_title,
+                "quantity": 1,
                 "scanned_at": scan_timestamp,
                 "time_from_order_start_seconds": time_from_order_start,
                 "confirmation_method": "scanned",
@@ -1111,6 +1127,7 @@ class PackerLogic(QObject):
             # SKU is not in this order at all
             # Example: User scanned wrong product, or product from different order
             self.unknown_scans.append(sku)
+            self.current_order_unknown_scan_count += 1
             return None, "SKU_NOT_FOUND"
 
     def clear_current_order(self):
@@ -1130,7 +1147,7 @@ class PackerLogic(QObject):
         if order_num not in skipped:
             skipped.append(order_num)
         # Record the skip timestamp for metrics
-        self.session_packing_state['skipped_orders_timing'][order_num] = get_current_timestamp()
+        self.session_packing_state.setdefault('skipped_orders_timing', {})[order_num] = get_current_timestamp()
         self.clear_current_order()
         self._check_all_complete()
         self._save_session_state_async()
@@ -1162,13 +1179,17 @@ class PackerLogic(QObject):
         item['packed'] -= 1
         self.current_order_corrections += 1
 
-        # Remove the most recent scan record for this item from the scan history so
-        # that items_count in the completed-order metadata reflects only final packed
-        # quantities (not cancelled intermediate scans).
+        # Adjust the most recent scan record for this item so that items_count in the
+        # completed-order metadata reflects only the final packed quantity.
+        # Records with quantity > 1 (e.g. a force-confirm record) are decremented rather
+        # than deleted, since only one unit is being cancelled.
         normalized_sku = item.get('normalized_sku', '')
         for i in range(len(self.current_order_items_scanned) - 1, -1, -1):
             if self.current_order_items_scanned[i].get('sku') == normalized_sku:
-                self.current_order_items_scanned.pop(i)
+                if self.current_order_items_scanned[i].get('quantity', 1) > 1:
+                    self.current_order_items_scanned[i]['quantity'] -= 1
+                else:
+                    self.current_order_items_scanned.pop(i)
                 break
 
         self.session_packing_state['in_progress'][self.current_order_number] = self.current_order_state
@@ -1203,16 +1224,23 @@ class PackerLogic(QObject):
         )
         items_list = self.orders_data[self.current_order_number]['items']
         item_idx = item.get('row', 0)
+        item_title = (
+            items_list[item_idx].get('Product_Name', item['normalized_sku'])
+            if 0 <= item_idx < len(items_list)
+            else item['normalized_sku']
+        )
+        # quantity = remaining units being force-confirmed (packed will jump from current to required)
+        remaining_qty = item['required'] - item['packed']
         force_record = {
             "sku": item['normalized_sku'],
-            "title": items_list[item_idx].get('Product_Name', item['normalized_sku']) if item_idx < len(items_list) else item['normalized_sku'],
-            "quantity": item['required'],
+            "title": item_title,
+            "quantity": remaining_qty,
             "scanned_at": force_timestamp,
             "time_from_order_start_seconds": time_from_start,
             "confirmation_method": "force_confirmed",
         }
-        # Only add record if the item wasn't already fully scanned (avoids duplicates)
-        if item['packed'] < item['required']:
+        # Only add record if there are remaining units to force-confirm
+        if remaining_qty > 0:
             self.current_order_items_scanned.append(force_record)
 
         item['packed'] = item['required']

--- a/src/session_browser/metrics_tab.py
+++ b/src/session_browser/metrics_tab.py
@@ -37,6 +37,8 @@ class MetricsTab(QWidget):
 
         # Check if metrics available
         metrics = self._get_metrics()
+        session_summary = self.details.get('session_summary', {})
+        is_incomplete = session_summary.get('status') == 'incomplete'
 
         if not metrics:
             no_data_label = QLabel(
@@ -50,73 +52,129 @@ class MetricsTab(QWidget):
             layout.addStretch()
             return
 
-        # Order Metrics Group
+        # Incomplete-session notice
+        if is_incomplete:
+            notice = QLabel(
+                "⚠️ Partial metrics — session was not fully completed.\n"
+                "Only data from completed orders is shown."
+            )
+            notice.setObjectName("incomplete_session_notice")
+            notice.setStyleSheet("color: #c87800; font-style: italic; padding: 4px;")
+            notice.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            layout.addWidget(notice)
+
+        # --- Order Metrics Group ---
         order_group = QGroupBox("Order Metrics")
         order_form = QFormLayout()
 
-        avg_order_time = metrics.get('avg_time_per_order', 0)
         order_form.addRow(
             "Average Time per Order:",
-            QLabel(self._format_seconds(avg_order_time))
+            QLabel(self._format_seconds(metrics.get('avg_time_per_order', 0)))
         )
-
-        fastest = metrics.get('fastest_order_seconds', 0)
         order_form.addRow(
             "Fastest Order:",
-            QLabel(self._format_seconds(fastest))
+            QLabel(self._format_seconds(metrics.get('fastest_order_seconds', 0)))
         )
-
-        slowest = metrics.get('slowest_order_seconds', 0)
         order_form.addRow(
             "Slowest Order:",
-            QLabel(self._format_seconds(slowest))
+            QLabel(self._format_seconds(metrics.get('slowest_order_seconds', 0)))
         )
+
+        avg_first_scan = metrics.get('avg_time_to_first_scan', 0)
+        if avg_first_scan:
+            order_form.addRow(
+                "Avg Time to First Scan:",
+                QLabel(self._format_seconds(avg_first_scan))
+            )
 
         order_group.setLayout(order_form)
         layout.addWidget(order_group)
 
-        # Item Metrics Group
+        # --- Item Metrics Group ---
         item_group = QGroupBox("Item Metrics")
         item_form = QFormLayout()
 
-        avg_item_time = metrics.get('avg_time_per_item', 0)
         item_form.addRow(
             "Average Time per Item:",
-            QLabel(self._format_seconds(avg_item_time))
+            QLabel(self._format_seconds(metrics.get('avg_time_per_item', 0)))
         )
 
         item_group.setLayout(item_form)
         layout.addWidget(item_group)
 
-        # Performance Rates Group
+        # --- Performance Rates Group ---
         rate_group = QGroupBox("Performance Rates")
         rate_form = QFormLayout()
 
-        orders_per_hour = metrics.get('orders_per_hour', 0)
         rate_form.addRow(
             "Orders per Hour:",
-            QLabel(f"{orders_per_hour:.1f}")
+            QLabel(f"{metrics.get('orders_per_hour', 0):.1f}")
         )
-
-        items_per_hour = metrics.get('items_per_hour', 0)
         rate_form.addRow(
             "Items per Hour:",
-            QLabel(f"{items_per_hour:.1f}")
+            QLabel(f"{metrics.get('items_per_hour', 0):.1f}")
         )
 
         rate_group.setLayout(rate_form)
         layout.addWidget(rate_group)
 
+        # --- Accuracy / Quality Group ---
+        quality_group = QGroupBox("Scan Quality")
+        quality_form = QFormLayout()
+
+        total_corrections = metrics.get('total_corrections', 0)
+        avg_corrections = metrics.get('avg_corrections_per_order', 0)
+        quality_form.addRow(
+            "Total Scan Corrections:",
+            QLabel(f"{total_corrections}")
+        )
+        quality_form.addRow(
+            "Avg Corrections per Order:",
+            QLabel(f"{avg_corrections:.2f}")
+        )
+
+        total_extra = metrics.get('total_extra_scans', 0)
+        quality_form.addRow(
+            "Total Extra Scans:",
+            QLabel(f"{total_extra}")
+        )
+
+        total_unknown = metrics.get('total_unknown_scans', 0)
+        quality_form.addRow(
+            "Total Unknown Scans:",
+            QLabel(f"{total_unknown}")
+        )
+
+        quality_group.setLayout(quality_form)
+        layout.addWidget(quality_group)
+
+        # --- Skipped Orders Group (show only if any exist) ---
+        skipped_orders = session_summary.get('skipped_orders', [])
+        skipped_count = session_summary.get('skipped_orders_count', len(skipped_orders))
+        if skipped_count or skipped_orders:
+            skipped_group = QGroupBox("Skipped Orders")
+            skipped_form = QFormLayout()
+
+            skipped_form.addRow(
+                "Skipped Orders Count:",
+                QLabel(str(skipped_count))
+            )
+
+            for entry in skipped_orders:
+                order_num = entry.get('order_number', '?')
+                skipped_at = entry.get('skipped_at')
+                label_text = self._format_timestamp(skipped_at) if skipped_at else "—"
+                skipped_form.addRow(f"  {order_num}:", QLabel(label_text))
+
+            skipped_group.setLayout(skipped_form)
+            layout.addWidget(skipped_group)
+
         layout.addStretch()
 
     def _get_metrics(self) -> dict:
         """Get metrics from session data."""
-
-        # Try session_summary first
         if 'session_summary' in self.details:
             return self.details['session_summary'].get('metrics', {})
-
-        # No metrics available
         return {}
 
     def _format_seconds(self, seconds: float) -> str:
@@ -133,3 +191,14 @@ class MetricsTab(QWidget):
             hours = seconds / 3600
             minutes = (seconds % 3600) / 60
             return f"{hours:.1f}h {minutes:.0f}m"
+
+    def _format_timestamp(self, ts: str) -> str:
+        """Format an ISO timestamp for display."""
+        if not ts:
+            return "—"
+        try:
+            from datetime import datetime
+            dt = datetime.fromisoformat(ts)
+            return dt.strftime("%Y-%m-%d %H:%M:%S")
+        except (ValueError, TypeError):
+            return ts

--- a/src/session_browser/orders_tab.py
+++ b/src/session_browser/orders_tab.py
@@ -5,6 +5,7 @@ from PySide6.QtWidgets import (
     QTreeWidget, QTreeWidgetItem, QLabel, QLineEdit
 )
 from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor
 
 from datetime import datetime
 from logger import get_logger
@@ -38,25 +39,30 @@ class OrdersTab(QWidget):
 
         # Try session_summary first (Phase 2b data with full timing)
         if 'session_summary' in self.details:
-            self.all_orders = self.details['session_summary'].get('orders', [])
-            logger.debug(f"Loaded {len(self.all_orders)} orders from session_summary")
+            orders = self.details['session_summary'].get('orders', [])
+            skipped = self.details['session_summary'].get('skipped_orders', [])
+            self.all_orders = list(orders) + list(skipped)
+            logger.debug(f"Loaded {len(orders)} completed + {len(skipped)} skipped orders")
             return
 
         # Fallback: Try packing_state (less detailed)
         if 'packing_state' in self.details:
             completed = self.details['packing_state'].get('completed', [])
-
-            # Convert to orders format (minimal data)
+            skipped = [
+                {"order_number": n, "skipped_at": None, "status": "skipped"}
+                for n in self.details['packing_state'].get('skipped_orders', [])
+            ]
             self.all_orders = [
                 {
                     'order_number': order.get('order_number', 'Unknown'),
                     'completed_at': order.get('completed_at', ''),
                     'items_count': order.get('items_count', 0),
                     'duration_seconds': order.get('duration_seconds', 0),
-                    'items': []  # No item-level data
+                    'items': []
                 }
                 for order in completed
-            ]
+                if isinstance(order, dict)
+            ] + skipped
 
     def _init_ui(self):
         """Initialize UI."""
@@ -85,17 +91,19 @@ class OrdersTab(QWidget):
         self.info_label = QLabel()
         layout.addWidget(self.info_label)
 
-        # Tree widget
+        # Tree widget — 6 columns (added "Flags" at the end)
         self.tree = QTreeWidget()
         self.tree.setHeaderLabels([
             "Order / Item",
             "Duration",
             "Count",
             "Started / Scanned",
-            "Completed"
+            "Completed",
+            "Flags",
         ])
         self.tree.setAlternatingRowColors(True)
         self.tree.setColumnWidth(0, 200)
+        self.tree.setColumnWidth(5, 140)
         layout.addWidget(self.tree)
 
     def _populate_tree(self):
@@ -108,7 +116,7 @@ class OrdersTab(QWidget):
         if search_term:
             self.filtered_orders = [
                 o for o in self.all_orders
-                if search_term in o.get('order_number', '').lower()
+                if search_term in str(o.get('order_number', '')).lower()
             ]
         else:
             self.filtered_orders = self.all_orders
@@ -124,66 +132,137 @@ class OrdersTab(QWidget):
 
         # Add orders to tree
         for order in self.filtered_orders:
+            is_skipped = order.get('status') == 'skipped'
+
             # Top level: Order
             order_item = QTreeWidgetItem(self.tree)
-            order_item.setText(0, order.get('order_number', 'Unknown'))
 
-            # Duration
-            duration = order.get('duration_seconds', 0)
-            if duration:
-                order_item.setText(1, f"{duration}s ({duration/60:.1f}m)")
+            order_label = order.get('order_number', 'Unknown')
+            if is_skipped:
+                order_label = f"[SKIPPED] {order_label}"
+            order_item.setText(0, order_label)
+
+            if is_skipped:
+                # Skipped order — show skip time, no duration/items
+                order_item.setText(1, "—")
+                order_item.setText(2, "—")
+                order_item.setText(3, self._format_timestamp(order.get('skipped_at', '')))
+                order_item.setText(4, "—")
+                order_item.setText(5, "⏭ skipped")
+                grey = QColor(150, 150, 150)
+                for col in range(6):
+                    order_item.setForeground(col, grey)
             else:
-                order_item.setText(1, "N/A")
+                # Duration
+                duration = order.get('duration_seconds', 0)
+                order_item.setText(1, f"{duration}s ({duration/60:.1f}m)" if duration else "N/A")
 
-            # Items count
-            items_count = order.get('items_count', len(order.get('items', [])))
-            order_item.setText(2, f"{items_count} items")
+                # Items count (actual scan events)
+                items_count = order.get('items_count', len(order.get('items', [])))
+                order_item.setText(2, f"{items_count} items")
 
-            # Started
-            started = self._format_timestamp(order.get('started_at', ''))
-            order_item.setText(3, started)
+                # Started
+                order_item.setText(3, self._format_timestamp(order.get('started_at', '')))
 
-            # Completed
-            completed = self._format_timestamp(order.get('completed_at', ''))
-            order_item.setText(4, completed)
+                # Completed
+                order_item.setText(4, self._format_timestamp(order.get('completed_at', '')))
 
-            # Make order bold
+                # Flags column: quality indicators
+                flags = self._build_order_flags(order)
+                order_item.setText(5, flags if flags else "✓ ok")
+
+                # Colour the flags cell if there are quality issues
+                if any(c in flags for c in ('⟲', '⚡', '+', '?')):
+                    order_item.setForeground(5, QColor(200, 160, 0))
+
+            # Make order row bold
             font = order_item.font(0)
             font.setBold(True)
-            for col in range(5):
+            for col in range(6):
                 order_item.setFont(col, font)
 
-            # Children: Items
+            if is_skipped:
+                continue
+
+            # --- Children: item scan records ---
             items = order.get('items', [])
             if items:
                 for item in items:
                     item_node = QTreeWidgetItem(order_item)
 
-                    # SKU
                     sku = item.get('sku', 'Unknown')
-                    item_node.setText(0, f"  → {sku}")
+                    method = item.get('confirmation_method', 'scanned')
+                    prefix = "⚡ " if method == 'force_confirmed' else "→ "
+                    item_node.setText(0, f"  {prefix}{sku}")
 
-                    # Time from order start
                     time_from_start = item.get('time_from_order_start_seconds', 0)
                     if time_from_start:
                         item_node.setText(1, f"+{time_from_start}s")
 
-                    # Quantity
                     qty = item.get('quantity', 1)
                     item_node.setText(2, f"×{qty}")
 
-                    # Scanned at
-                    scanned = self._format_timestamp(item.get('scanned_at', ''))
-                    item_node.setText(3, scanned)
+                    item_node.setText(3, self._format_timestamp(item.get('scanned_at', '')))
+
+                    # Show method in flags column
+                    if method == 'force_confirmed':
+                        item_node.setText(5, "⚡ manual")
+                        item_node.setForeground(5, QColor(200, 120, 0))
+                    else:
+                        item_node.setText(5, "✓ scan")
             else:
-                # No item-level data
                 no_data_node = QTreeWidgetItem(order_item)
                 no_data_node.setText(0, "  (Item details not available)")
                 no_data_node.setForeground(0, Qt.GlobalColor.gray)
 
+            # --- Quality summary sub-nodes (corrections, extras, unknowns) ---
+            corrections = order.get('corrections', 0)
+            extra_scans = order.get('extra_scans_count', 0)
+            unknown_scans = order.get('unknown_scans_count', 0)
+            first_scan = order.get('time_to_first_scan_seconds')
+
+            if corrections:
+                c_node = QTreeWidgetItem(order_item)
+                c_node.setText(0, f"  ⟲ {corrections} scan correction(s) (Undo pressed)")
+                c_node.setForeground(0, QColor(180, 120, 0))
+
+            if extra_scans:
+                e_node = QTreeWidgetItem(order_item)
+                e_node.setText(0, f"  + {extra_scans} extra scan(s) (over-scanned SKU)")
+                e_node.setForeground(0, QColor(160, 100, 0))
+
+            if unknown_scans:
+                u_node = QTreeWidgetItem(order_item)
+                u_node.setText(0, f"  ? {unknown_scans} unknown scan(s) (wrong barcode)")
+                u_node.setForeground(0, QColor(180, 60, 60))
+
+            if first_scan is not None:
+                fs_node = QTreeWidgetItem(order_item)
+                fs_node.setText(0, f"  ⏱ First scan after {first_scan}s from order start")
+                fs_node.setForeground(0, Qt.GlobalColor.gray)
+
         # Auto-expand if few orders
         if len(self.filtered_orders) <= 10:
             self.tree.expandAll()
+
+    def _build_order_flags(self, order: dict) -> str:
+        """Build a short flags string for the order's quality indicators."""
+        parts = []
+        corrections = order.get('corrections', 0)
+        extra_scans = order.get('extra_scans_count', 0)
+        unknown_scans = order.get('unknown_scans_count', 0)
+        items = order.get('items', [])
+        has_force = any(i.get('confirmation_method') == 'force_confirmed' for i in items)
+
+        if has_force:
+            parts.append("⚡ manual")
+        if corrections:
+            parts.append(f"⟲{corrections}")
+        if extra_scans:
+            parts.append(f"+{extra_scans} extra")
+        if unknown_scans:
+            parts.append(f"?{unknown_scans} unkn")
+        return "  ".join(parts)
 
     def _on_search(self):
         """Handle search text change."""
@@ -195,7 +274,6 @@ class OrdersTab(QWidget):
             return "N/A"
 
         try:
-            # Handle both ISO formats with and without timezone
             ts_clean = ts.replace('Z', '+00:00')
             dt = datetime.fromisoformat(ts_clean)
             return dt.strftime("%H:%M:%S")

--- a/src/session_browser/overview_tab.py
+++ b/src/session_browser/overview_tab.py
@@ -106,8 +106,9 @@ class OverviewTab(QWidget):
                 QLabel(str(total_items))
             )
 
-            # Status
-            if completed_orders == total_orders:
+            # Status — count skipped orders toward completion
+            skipped_orders_count = record.get('skipped_orders_count', 0)
+            if total_orders > 0 and (completed_orders + skipped_orders_count) >= total_orders:
                 status = "✅ Complete"
             else:
                 status = f"⚠️ Incomplete ({in_progress_orders} in progress)"

--- a/src/session_browser/session_details_dialog.py
+++ b/src/session_browser/session_details_dialog.py
@@ -109,7 +109,8 @@ class SessionDetailsDialog(QDialog):
                     'duration_seconds': session_summary.get('duration_seconds', 0),
                     'total_orders': session_summary.get('total_orders', 0),
                     'completed_orders': session_summary.get('completed_orders', 0),
-                    'in_progress_orders': 0,
+                    'in_progress_orders': session_summary.get('in_progress_orders', 0),
+                    'skipped_orders_count': session_summary.get('skipped_orders_count', 0),
                     'total_items_packed': session_summary.get('total_items', 0)
                 }
             elif session_info:
@@ -127,10 +128,19 @@ class SessionDetailsDialog(QDialog):
                     'total_orders': packing_state.get('total_orders', 0),
                     'completed_orders': len(packing_state.get('completed', [])),
                     'in_progress_orders': len(packing_state.get('in_progress', [])),
+                    'skipped_orders_count': len(packing_state.get('skipped_orders', [])),
                     'total_items_packed': sum(o.get('items_count', 0) for o in packing_state.get('completed', []))
                 }
             else:
                 raise ValueError(f"No valid session data found in work_dir: {work_dir}")
+
+            # For incomplete sessions (no session_summary.json), build a partial summary
+            # from the completed orders stored in packing_state.json so that MetricsTab
+            # can display whatever metrics are available instead of "Metrics not available".
+            if not session_summary and packing_state:
+                session_summary = self._build_partial_summary(packing_state, session_info)
+                if session_summary:
+                    logger.info("Built partial session summary from packing_state.json")
 
             self.details = {
                 'record': record,
@@ -266,6 +276,126 @@ class SessionDetailsDialog(QDialog):
 
         return []
 
+    def _build_partial_summary(self, packing_state: dict, session_info: dict) -> dict:
+        """Build a minimal session_summary-compatible dict from packing_state for incomplete sessions.
+
+        Called when session_summary.json does not yet exist (session ended without full completion).
+        Computes the same metrics that generate_session_summary() would compute, but from the
+        data available in packing_state.json.
+
+        Returns an empty dict if there is insufficient data to compute any metrics.
+        """
+        completed_orders = packing_state.get('completed', [])
+        if not completed_orders:
+            return {}
+
+        # Only orders with timing metadata contribute to metrics
+        orders_with_timing = [o for o in completed_orders if isinstance(o, dict) and o.get('duration_seconds')]
+
+        if not orders_with_timing:
+            # No timing data — return minimal summary with just counts
+            return {
+                'metrics': {},
+                'orders': [o for o in completed_orders if isinstance(o, dict)],
+                'skipped_orders': [
+                    {"order_number": n, "skipped_at": None, "status": "skipped"}
+                    for n in packing_state.get('skipped_orders', [])
+                ],
+                'skipped_orders_count': len(packing_state.get('skipped_orders', [])),
+                'completed_orders': len([o for o in completed_orders if isinstance(o, dict)]),
+                'total_orders': packing_state.get('progress', {}).get('total_orders', 0),
+                'started_at': session_info.get('started_at') or packing_state.get('started_at'),
+                'status': 'incomplete',
+            }
+
+        # Compute the same metrics as generate_session_summary()
+        durations = [o['duration_seconds'] for o in orders_with_timing]
+        avg_time_per_order = round(sum(durations) / len(durations), 1)
+        fastest_order_seconds = min(durations)
+        slowest_order_seconds = max(durations)
+
+        all_items = []
+        for order in orders_with_timing:
+            all_items.extend(order.get('items', []))
+        item_times = [
+            item['time_from_order_start_seconds']
+            for item in all_items
+            if 'time_from_order_start_seconds' in item
+        ]
+        avg_time_per_item = round(sum(item_times) / len(item_times), 1) if item_times else 0
+
+        # 1.7 metrics
+        first_scan_latencies = [
+            o['time_to_first_scan_seconds']
+            for o in orders_with_timing
+            if o.get('time_to_first_scan_seconds') is not None
+        ]
+        avg_time_to_first_scan = (
+            round(sum(first_scan_latencies) / len(first_scan_latencies), 1)
+            if first_scan_latencies else 0
+        )
+        total_corrections = sum(o.get('corrections', 0) for o in orders_with_timing)
+        total_extra_scans = sum(o.get('extra_scans_count', 0) for o in orders_with_timing)
+        total_unknown_scans = sum(o.get('unknown_scans_count', 0) for o in orders_with_timing)
+        avg_corrections_per_order = (
+            round(total_corrections / len(orders_with_timing), 2) if orders_with_timing else 0
+        )
+
+        # Session duration from state timestamps (best-effort)
+        started_at = session_info.get('started_at') or packing_state.get('started_at')
+        last_updated = packing_state.get('last_updated')
+        duration_seconds = 0
+        orders_per_hour = 0
+        items_per_hour = 0
+        if started_at and last_updated:
+            try:
+                from datetime import datetime
+                start_dt = datetime.fromisoformat(started_at)
+                end_dt = datetime.fromisoformat(last_updated)
+                duration_seconds = max(0, int((end_dt - start_dt).total_seconds()))
+                if duration_seconds > 0:
+                    hours = duration_seconds / 3600.0
+                    orders_per_hour = round(len(orders_with_timing) / hours, 1)
+                    total_items_packed = sum(o.get('items_count', 0) for o in orders_with_timing)
+                    if total_items_packed > 0:
+                        items_per_hour = round(total_items_packed / hours, 1)
+            except (ValueError, TypeError):
+                pass
+
+        # Count in-progress orders from raw in_progress dict (exclude _timing key)
+        raw_in_progress = packing_state.get('in_progress', {})
+        in_progress_count = sum(1 for k in raw_in_progress if not k.startswith('_'))
+
+        skipped_timing = packing_state.get('skipped_orders_timing', {})
+        return {
+            'status': 'incomplete',
+            'started_at': started_at,
+            'completed_at': last_updated,
+            'duration_seconds': duration_seconds,
+            'total_orders': packing_state.get('progress', {}).get('total_orders', 0),
+            'completed_orders': len([o for o in completed_orders if isinstance(o, dict)]),
+            'in_progress_orders': in_progress_count,
+            'skipped_orders_count': len(packing_state.get('skipped_orders', [])),
+            'metrics': {
+                'avg_time_per_order': avg_time_per_order,
+                'avg_time_per_item': avg_time_per_item,
+                'fastest_order_seconds': fastest_order_seconds,
+                'slowest_order_seconds': slowest_order_seconds,
+                'orders_per_hour': orders_per_hour,
+                'items_per_hour': items_per_hour,
+                'avg_time_to_first_scan': avg_time_to_first_scan,
+                'total_corrections': total_corrections,
+                'avg_corrections_per_order': avg_corrections_per_order,
+                'total_extra_scans': total_extra_scans,
+                'total_unknown_scans': total_unknown_scans,
+            },
+            'orders': [o for o in completed_orders if isinstance(o, dict)],
+            'skipped_orders': [
+                {"order_number": n, "skipped_at": skipped_timing.get(n), "status": "skipped"}
+                for n in packing_state.get('skipped_orders', [])
+            ],
+        }
+
     def _is_standardized_data(self, data: dict) -> bool:
         """Check if session_data is in standardized format (has all required fields)."""
         required_fields = ['session_id', 'client_id', 'packing_list_name', 'status']
@@ -306,7 +436,8 @@ class SessionDetailsDialog(QDialog):
             'duration_seconds': data.get('duration_seconds', 0),
             'total_orders': data.get('orders_total', 0),
             'completed_orders': data.get('orders_completed', 0),
-            'in_progress_orders': 0,
+            'in_progress_orders': data.get('in_progress_orders', 0),
+            'skipped_orders_count': data.get('skipped_orders_count', 0),
             'total_items_packed': data.get('items_packed', 0)
         }
 
@@ -343,6 +474,14 @@ class SessionDetailsDialog(QDialog):
                             record['worker_name'] = session_summary['worker_name']
                 except Exception as e:
                     logger.warning(f"Failed to load session_summary.json: {e}")
+
+        # Same partial-metrics fallback as the work_dir path: build from packing_state when
+        # session_summary.json hasn't been created yet (incomplete session).
+        if not session_summary and packing_state:
+            session_info_hint = {'started_at': data.get('started_at')}
+            session_summary = self._build_partial_summary(packing_state, session_info_hint)
+            if session_summary:
+                logger.info("Built partial session summary from packing_state.json (standardized path)")
 
         self.details = {
             'record': record,

--- a/src/session_browser/session_details_dialog.py
+++ b/src/session_browser/session_details_dialog.py
@@ -125,9 +125,12 @@ class SessionDetailsDialog(QDialog):
                     'start_time': session_info.get('started_at', ''),
                     'end_time': None,
                     'duration_seconds': 0,
-                    'total_orders': packing_state.get('total_orders', 0),
+                    'total_orders': packing_state.get('progress', {}).get('total_orders', 0),
                     'completed_orders': len(packing_state.get('completed', [])),
-                    'in_progress_orders': len(packing_state.get('in_progress', [])),
+                    'in_progress_orders': sum(
+                        1 for k in packing_state.get('in_progress', {})
+                        if not k.startswith('_')
+                    ),
                     'skipped_orders_count': len(packing_state.get('skipped_orders', [])),
                     'total_items_packed': sum(o.get('items_count', 0) for o in packing_state.get('completed', []))
                 }

--- a/tests/test_state_persistence.py
+++ b/tests/test_state_persistence.py
@@ -581,7 +581,7 @@ class TestCrashRecovery(unittest.TestCase):
         packer = PackerLogic("TEST", self.mock_profile_manager, str(self.work_dir))
 
         # Verify it starts with fresh state
-        self.assertEqual(packer.session_packing_state, {'in_progress': {}, 'completed_orders': [], 'skipped_orders': []})
+        self.assertEqual(packer.session_packing_state, {'in_progress': {}, 'completed_orders': [], 'skipped_orders': [], 'skipped_orders_timing': {}})
         self.assertIsNone(packer.session_id)
 
     def test_state_metadata_complete(self):


### PR DESCRIPTION
….3.0)

- Fix critical init-order bug: Phase 2b timing vars now declared before _load_session_state(), preventing completed_orders_metadata from being wiped on every session load (root cause of all metrics display failures)
- Fix resumed sessions: start_order_packing() now preserves timing/scan history for in-progress orders instead of always resetting to zero
- Add confirmation_method field ('scanned'/'force_confirmed') to every item scan record; force_confirm_item() now appends scan records so order metadata has full item history
- Track per-order quality counters: corrections, extra_scans_count, unknown_scans_count, time_to_first_scan_seconds
- Fix cancel_item_scan(): removes the cancelled scan record from current_order_items_scanned to prevent inflated items_count
- Track skipped-order timestamps in skipped_orders_timing dict; include skipped_orders list with timestamps in session_summary
- generate_session_summary() now aggregates all 1.7 metrics: avg/fast/ slow order times, items/hour, orders/hour, correction rates, first-scan latency, extra/unknown scan totals, in_progress_orders count
- Add _build_partial_summary() to session_details_dialog.py: computes metrics from packing_state.json when session_summary.json absent (incomplete sessions no longer show "Metrics not available")
- Rewrite metrics_tab.py with Order/Item/Rate/Scan Quality/Skipped groups
- Rewrite orders_tab.py with Flags column, per-order quality indicators (⚡ manual, ⟲ corrections, + extras, ? unknowns), and skipped-order rows
- Fix overview_tab.py: session status now counts skipped orders toward completion (completed + skipped >= total → "✅ Complete")
- Add skipped_orders_count to record dict in all three build paths of session_details_dialog.py
- Fix _on_force_confirm() in main.py: show "REVIEW EXTRA ITEMS!" and extras panel when all items are force-confirmed but extras remain
- Fix three reset paths in _load_session_state() missing skipped_orders_timing

## Summary by Sourcery

Overhaul scan metrics and session reporting to capture timing, quality, and skipped-order data, and surface them across the packer UI and session browser.

New Features:
- Track per-order timing, first-scan latency, and scan-quality counters (corrections, extras, unknowns) in session summaries.
- Record confirmation method for each item scan and include force-confirmed items in per-order scan history.
- Capture skipped orders with timestamps and expose them in summaries, metrics, and orders views.
- Provide a partial session summary built from packing_state for incomplete sessions so metrics still display in the UI.

Bug Fixes:
- Preserve timing and scan history when resuming in-progress orders instead of resetting on start.
- Fix session state initialization order so completed order metadata and timing fields are not wiped on load.
- Ensure canceling an item scan removes the corresponding scan record to avoid inflated item counts.
- Show correct visual feedback and extra-items warning when force-confirming items with outstanding extras.
- Treat skipped orders as contributing to overall session completion status in the overview.

Enhancements:
- Enrich generate_session_summary with full timing, throughput, and quality metrics plus in-progress and skipped-order counts.
- Update orders tab to display flags and per-order quality indicators, including skipped-order rows and item-level confirmation methods.
- Extend metrics tab with grouped order, item, performance, quality, and skipped-order statistics, including partial-metrics notice for incomplete sessions.
- Standardize session record fields to carry in-progress and skipped-order counts through the session browser.

Tests:
- Adjust state persistence tests to cover the extended session state structure including skipped order timing.