### PR TITLE
fix: update file server path to new network location

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -3,7 +3,7 @@
 
 [Network]
 # File server path - all data stored here
-FileServerPath = \\192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment
+FileServerPath = \\192.168.88.101\_Fulfilment_\0UFulfilment
 ConnectionTimeout = 5
 LocalCachePath =
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -47,7 +47,7 @@ Record analysis completion:
 from shared import StatsManager
 
 # Initialize (pass path to 0UFulfilment directory)
-base_path = r"\\192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment"
+base_path = r"\\192.168.88.101\_Fulfilment_\0UFulfilment"
 stats_manager = StatsManager(base_path)
 
 # After completing analysis
@@ -70,7 +70,7 @@ Record packing session completion:
 from shared import StatsManager
 
 # Initialize
-base_path = r"\\192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment"
+base_path = r"\\192.168.88.101\_Fulfilment_\0UFulfilment"
 stats_manager = StatsManager(base_path)
 
 # After completing packing session

--- a/shared/stats_manager.py
+++ b/shared/stats_manager.py
@@ -605,7 +605,7 @@ class StatsManager:
 # Example usage
 if __name__ == "__main__":
     # Example for testing
-    base_path = r"\\192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment"
+    base_path = r"\\192.168.88.101\_Fulfilment_\0UFulfilment"
 
     # Create manager
     manager = StatsManager(base_path)

--- a/src/config.ini
+++ b/src/config.ini
@@ -3,7 +3,7 @@
 
 [Network]
 # File server path - all data stored here
-FileServerPath = \\192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment
+FileServerPath = \\192.168.88.101\_Fulfilment_\0UFulfilment
 ConnectionTimeout = 5
 LocalCachePath =
 

--- a/src/logger.py
+++ b/src/logger.py
@@ -195,7 +195,7 @@ class AppLogger:
         # Store logs on centralized file server for unified logging
         # Get base path from config
         file_server_path = config.get('Network', 'FileServerPath',
-                                      fallback=r'\\192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment')
+                                      fallback=r'\\192.168.88.101\_Fulfilment_\0UFulfilment')
 
         # Centralized logs location: \\server\...\0UFulfilment\Logs\packing_tool\
         log_dir = Path(file_server_path) / "Logs" / "packing_tool"

--- a/tests/verify_logging.py
+++ b/tests/verify_logging.py
@@ -68,7 +68,7 @@ def main():
         config.read('config.ini')
 
         file_server_path = config.get('Network', 'FileServerPath',
-                                     fallback=r'\\192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment')
+                                     fallback=r'\\192.168.88.101\_Fulfilment_\0UFulfilment')
 
         log_dir = Path(file_server_path) / "Logs" / "packing_tool"
         log_file = log_dir / f"{datetime.now():%Y-%m-%d}.log"


### PR DESCRIPTION
Replace \192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment with \192.168.88.101\_Fulfilment_\0UFulfilment across all config and source files.

## Summary by Sourcery

Update the configured network file server path to the new 0UFulfilment share across code, configuration, documentation, and tests.

Bug Fixes:
- Point all hard-coded file server paths to the new network share to ensure correct access to shared resources.

Documentation:
- Adjust README examples to reference the new network file server path.

Tests:
- Update logging verification test configuration to use the new network file server path.

Chores:
- Align default and fallback file server paths in configs and logger with the updated network location.