### PR TITLE
fix: thread safety, stale-lock classification, and atomic writes

### DIFF
--- a/src/json_cache.py
+++ b/src/json_cache.py
@@ -31,6 +31,7 @@ Version: 1.0.0
 
 import json
 import time
+import threading
 from pathlib import Path
 from typing import Dict, Any, Optional
 import logging
@@ -92,6 +93,8 @@ class JSONCache:
         self.ttl_seconds = ttl_seconds
         self._cache: Dict[str, Dict[str, Any]] = {}
         self._access_times: Dict[str, float] = {}
+        self._insert_times: Dict[str, float] = {}
+        self._lock = threading.RLock()
 
         logger.debug(f"JSONCache initialized: max_size={max_size}, ttl={ttl_seconds}s")
 
@@ -128,50 +131,53 @@ class JSONCache:
         cache_key = str(file_path.absolute())
         current_time = time.time()
 
-        # Check if cached and not expired
-        if cache_key in self._cache:
-            cache_age = current_time - self._access_times[cache_key]
+        with self._lock:
+            # Check if cached and not expired (TTL based on insert time, not access time)
+            if cache_key in self._cache:
+                cache_age = current_time - self._insert_times[cache_key]
 
-            if cache_age < self.ttl_seconds:
-                # Cache hit - update access time for LRU tracking
-                self._access_times[cache_key] = current_time
-                logger.debug(f"Cache HIT: {file_path.name} (age: {cache_age:.1f}s)")
-                return self._cache[cache_key]
-            else:
-                # Cache expired - remove stale entry
-                logger.debug(f"Cache EXPIRED: {file_path.name} (age: {cache_age:.1f}s)")
-                del self._cache[cache_key]
-                del self._access_times[cache_key]
+                if cache_age < self.ttl_seconds:
+                    # Cache hit - update access time for LRU tracking only
+                    self._access_times[cache_key] = current_time
+                    logger.debug(f"Cache HIT: {file_path.name} (age: {cache_age:.1f}s)")
+                    return self._cache[cache_key]
+                else:
+                    # Cache expired - remove stale entry
+                    logger.debug(f"Cache EXPIRED: {file_path.name} (age: {cache_age:.1f}s)")
+                    del self._cache[cache_key]
+                    del self._access_times[cache_key]
+                    del self._insert_times[cache_key]
 
-        # Cache miss - read from file
+        # Cache miss — read from disk without holding the lock so other threads
+        # can serve their own cache hits concurrently during a slow network read.
         try:
             if not file_path.exists():
                 logger.debug(f"File not found: {file_path}")
                 return default
 
-            # Read and parse JSON
             with open(file_path, 'r', encoding='utf-8') as f:
                 data = json.load(f)
 
-            # Add to cache
-            self._cache[cache_key] = data
-            self._access_times[cache_key] = current_time
-
-            # Evict oldest entries if cache is full
-            if len(self._cache) > self.max_size:
-                self._evict_oldest()
-
-            logger.debug(f"Cache MISS: {file_path.name} loaded and cached")
-            return data
-
         except json.JSONDecodeError as e:
-            # Invalid JSON format
             logger.warning(f"Invalid JSON in {file_path}: {e}")
             return default
         except Exception as e:
-            # Other errors (permissions, I/O errors, etc.)
             logger.error(f"Error reading {file_path}: {e}")
             return default
+
+        # Re-acquire lock to insert; another thread may have beat us here —
+        # only insert if the key is still absent to avoid replacing newer data.
+        now = time.time()
+        with self._lock:
+            if cache_key not in self._cache:
+                self._cache[cache_key] = data
+                self._access_times[cache_key] = now
+                self._insert_times[cache_key] = now
+                if len(self._cache) > self.max_size:
+                    self._evict_oldest()
+                logger.debug(f"Cache MISS: {file_path.name} loaded and cached")
+
+        return data
 
     def _evict_oldest(self):
         """
@@ -182,9 +188,9 @@ class JSONCache:
         - Remove oldest 10% of entries
         - This batch eviction is more efficient than removing one at a time
 
-        Called automatically when cache exceeds max_size.
+        Must be called with self._lock already held.
         """
-        # Sort by access time (oldest first)
+        # Sort by access time (oldest first) for LRU eviction
         sorted_keys = sorted(self._access_times.items(), key=lambda x: x[1])
 
         # Remove oldest 10% of entries (minimum 1)
@@ -193,6 +199,7 @@ class JSONCache:
         for cache_key, _ in sorted_keys[:remove_count]:
             del self._cache[cache_key]
             del self._access_times[cache_key]
+            del self._insert_times[cache_key]
             logger.debug(f"Evicted from cache: {Path(cache_key).name}")
 
         logger.debug(f"Cache eviction: removed {remove_count} entries")
@@ -216,10 +223,12 @@ class JSONCache:
             >>> cache.invalidate(state_file)
         """
         cache_key = str(Path(file_path).absolute())
-        if cache_key in self._cache:
-            del self._cache[cache_key]
-            del self._access_times[cache_key]
-            logger.debug(f"Cache invalidated: {file_path.name if isinstance(file_path, Path) else file_path}")
+        with self._lock:
+            if cache_key in self._cache:
+                del self._cache[cache_key]
+                del self._access_times[cache_key]
+                del self._insert_times[cache_key]
+                logger.debug(f"Cache invalidated: {file_path.name if isinstance(file_path, Path) else file_path}")
 
     def clear(self):
         """
@@ -230,10 +239,12 @@ class JSONCache:
         - Freeing memory when cache is no longer needed
         - Force-refreshing all data from disk
         """
-        entry_count = len(self._cache)
-        self._cache.clear()
-        self._access_times.clear()
-        logger.info(f"Cache cleared: {entry_count} entries removed")
+        with self._lock:
+            entry_count = len(self._cache)
+            self._cache.clear()
+            self._access_times.clear()
+            self._insert_times.clear()
+            logger.info(f"Cache cleared: {entry_count} entries removed")
 
     def stats(self) -> Dict[str, Any]:
         """
@@ -254,17 +265,18 @@ class JSONCache:
             >>> print(f"Cache utilization: {stats['size']}/{stats['max_size']}")
             >>> print(f"Oldest entry: {stats['oldest_age']:.1f}s old")
         """
-        oldest_age = 0
-        if self._access_times:
-            oldest_time = min(self._access_times.values())
-            oldest_age = time.time() - oldest_time
+        with self._lock:
+            oldest_age = 0
+            if self._access_times:
+                oldest_time = min(self._access_times.values())
+                oldest_age = time.time() - oldest_time
 
-        return {
-            'size': len(self._cache),
-            'max_size': self.max_size,
-            'ttl_seconds': self.ttl_seconds,
-            'oldest_age': round(oldest_age, 1)
-        }
+            return {
+                'size': len(self._cache),
+                'max_size': self.max_size,
+                'ttl_seconds': self.ttl_seconds,
+                'oldest_age': round(oldest_age, 1)
+            }
 
 
 # ============================================================================

--- a/src/main.py
+++ b/src/main.py
@@ -1442,7 +1442,7 @@ class MainWindow(QMainWindow):
             self.current_work_dir = str(work_dir)
 
             # 3. Acquire lock on work directory (with stale lock handling)
-            success, error_msg = self.lock_manager.acquire_lock(
+            success, error_msg, _ = self.lock_manager.acquire_lock(
                 client_id=client_id,
                 session_dir=work_dir,
                 worker_id=self.current_worker_id,
@@ -1459,7 +1459,7 @@ class MainWindow(QMainWindow):
                     )
                     if reply == QMessageBox.Yes:
                         self.lock_manager.force_release_lock(work_dir)
-                        success, error_msg = self.lock_manager.acquire_lock(
+                        success, error_msg, _ = self.lock_manager.acquire_lock(
                             client_id,
                             work_dir,
                             worker_id=self.current_worker_id,
@@ -2449,7 +2449,7 @@ class MainWindow(QMainWindow):
                 self.current_work_dir = str(work_dir)
 
                 # Acquire lock
-                success, error_msg = self.lock_manager.acquire_lock(
+                success, error_msg, _ = self.lock_manager.acquire_lock(
                     self.current_client_id,
                     work_dir,
                     worker_id=self.current_worker_id,
@@ -2465,7 +2465,7 @@ class MainWindow(QMainWindow):
                         )
                         if reply == QMessageBox.Yes:
                             self.lock_manager.force_release_lock(work_dir)
-                            success, error_msg = self.lock_manager.acquire_lock(
+                            success, error_msg, _ = self.lock_manager.acquire_lock(
                                 self.current_client_id,
                                 work_dir,
                                 worker_id=self.current_worker_id,

--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -107,6 +107,8 @@ class PackerLogic(QObject):
         self.packing_list_df = None
         self.processed_df = None
         self.orders_data = {}
+        self._normalized_order_lookup: Dict[str, str] = {}
+        self._total_items: int = 0
         self.current_order_number = None
         self.current_order_state = {}
 
@@ -231,14 +233,7 @@ class PackerLogic(QObject):
         For unified workflow: work_dir/packing_state.json
         For Excel workflow: barcodes/packing_state.json (backward compatible)
         """
-        # For unified workflow, state file goes in work_dir root
-        # For Excel workflow (work_dir == barcodes), state file is still in barcodes dir
-        if self.work_dir.name == "barcodes":
-            # Excel workflow: keep state in barcodes directory
-            return str(self.work_dir / STATE_FILE_NAME)
-        else:
-            # Unified workflow: state in work_dir root
-            return str(self.work_dir / STATE_FILE_NAME)
+        return str(self.work_dir / STATE_FILE_NAME)
 
     def _get_summary_file_path(self) -> str:
         """
@@ -247,12 +242,7 @@ class PackerLogic(QObject):
         For unified workflow: work_dir/session_summary.json
         For Excel workflow: barcodes/session_summary.json (backward compatible)
         """
-        if self.work_dir.name == "barcodes":
-            # Excel workflow: keep summary in barcodes directory
-            return str(self.work_dir / SUMMARY_FILE_NAME)
-        else:
-            # Unified workflow: summary in work_dir root
-            return str(self.work_dir / SUMMARY_FILE_NAME)
+        return str(self.work_dir / SUMMARY_FILE_NAME)
 
     def _load_session_state(self):
         """
@@ -466,26 +456,8 @@ class PackerLogic(QObject):
         total_orders = len(self.orders_data) if self.orders_data else 0
         completed_orders_count = len(self.session_packing_state.get('completed_orders', []))
 
-        total_items = 0
-        packed_items = 0
-
-        if self.processed_df is not None:
-            try:
-                total_items = int(pd.to_numeric(self.processed_df['Quantity'], errors='coerce').sum())
-            except Exception as e:
-                logger.warning(f"Could not calculate total_items: {e}")
-
-        if self.processed_df is not None and self.session_packing_state.get('completed_orders'):
-            try:
-                completed_items = pd.to_numeric(
-                    self.processed_df[
-                        self.processed_df['Order_Number'].isin(self.session_packing_state['completed_orders'])
-                    ]['Quantity'],
-                    errors='coerce'
-                ).sum()
-                packed_items += int(completed_items)
-            except Exception as e:
-                logger.warning(f"Could not calculate packed items from completed orders: {e}")
+        total_items = self._total_items
+        packed_items = sum(o.get('items_count', 0) for o in self.completed_orders_metadata)
 
         for order_state in self.session_packing_state.get('in_progress', {}).values():
             if isinstance(order_state, list):
@@ -821,6 +793,9 @@ class PackerLogic(QObject):
 
         return normalized
 
+    def _build_order_lookup(self):
+        self._build_order_lookup()
+
     def start_order_packing(self, scanned_text: str) -> Tuple[List[Dict] | None, str]:
         """
         Starts or resumes packing an order based on a scanned barcode.
@@ -841,14 +816,10 @@ class PackerLogic(QObject):
         scanned_normalized = self._normalize_order_number(scanned_text)
         logger.debug(f"Scanned text: '{scanned_text}' -> Normalized: '{scanned_normalized}'")
 
-        # Find matching order in orders_data
-        matched_order_number = None
-        for order_number in self.orders_data.keys():
-            order_normalized = self._normalize_order_number(order_number)
-            if scanned_normalized == order_normalized:
-                matched_order_number = order_number
-                logger.debug(f"Match found: '{scanned_text}' matches order '{order_number}'")
-                break
+        # Find matching order in orders_data via pre-built normalized lookup (O(1))
+        matched_order_number = self._normalized_order_lookup.get(scanned_normalized)
+        if matched_order_number:
+            logger.debug(f"Match found: '{scanned_text}' matches order '{matched_order_number}'")
 
         if not matched_order_number:
             logger.info(f"Order not found for scanned text: '{scanned_text}'")
@@ -982,9 +953,6 @@ class PackerLogic(QObject):
 
         # Normalize the final SKU (whether mapped or direct)
         # This ensures consistent matching even if mapping returns non-normalized value
-        normalized_final_sku = self._normalize_sku(final_sku)
-
-        # The rest of the logic uses the potentially translated SKU.
         normalized_final_sku = self._normalize_sku(final_sku)
 
         # === STEP 3: Find matching item in current order ===
@@ -1473,6 +1441,7 @@ class PackerLogic(QObject):
         # Store as packing_list_df and processed_df
         self.packing_list_df = df
         self.processed_df = df.copy()
+        self._total_items = int(pd.to_numeric(df['Quantity'], errors='coerce').sum())
 
         logger.info(f"Converted {len(df)} items from {len(orders_list)} orders to DataFrame")
 
@@ -1495,6 +1464,8 @@ class PackerLogic(QObject):
                     'order_fulfillment_status': raw.get('order_fulfillment_status') or '',
                 },
             }
+
+        self._build_order_lookup()
 
         # Initialize session metadata
         # Extract session_id from path if available (e.g., .../Sessions/CLIENT_M/2025-11-10_1/...)
@@ -1660,6 +1631,7 @@ class PackerLogic(QObject):
         # Store as packing_list_df and processed_df
         self.packing_list_df = df
         self.processed_df = df.copy()
+        self._total_items = int(pd.to_numeric(df['Quantity'], errors='coerce').sum())
 
         logger.info(f"Converted {len(df)} items from {len(orders_list)} orders to DataFrame")
 
@@ -1682,6 +1654,8 @@ class PackerLogic(QObject):
                     'order_fulfillment_status': raw.get('order_fulfillment_status') or '',
                 },
             }
+
+        self._build_order_lookup()
 
         # Initialize session metadata
         # Extract session_id from session_path (e.g., .../Sessions/CLIENT_M/2025-11-10_1)

--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -794,7 +794,10 @@ class PackerLogic(QObject):
         return normalized
 
     def _build_order_lookup(self):
-        self._build_order_lookup()
+        self._normalized_order_lookup = {
+            self._normalize_order_number(order_number): order_number
+            for order_number in self.orders_data
+        }
 
     def start_order_packing(self, scanned_text: str) -> Tuple[List[Dict] | None, str]:
         """
@@ -815,6 +818,10 @@ class PackerLogic(QObject):
         # STEP 1: Find order using normalized comparison
         scanned_normalized = self._normalize_order_number(scanned_text)
         logger.debug(f"Scanned text: '{scanned_text}' -> Normalized: '{scanned_normalized}'")
+
+        # Lazy-build the lookup if orders_data was set directly (e.g. in tests)
+        if not self._normalized_order_lookup and self.orders_data:
+            self._build_order_lookup()
 
         # Find matching order in orders_data via pre-built normalized lookup (O(1))
         matched_order_number = self._normalized_order_lookup.get(scanned_normalized)
@@ -1441,7 +1448,11 @@ class PackerLogic(QObject):
         # Store as packing_list_df and processed_df
         self.packing_list_df = df
         self.processed_df = df.copy()
-        self._total_items = int(pd.to_numeric(df['Quantity'], errors='coerce').sum())
+        try:
+            self._total_items = int(pd.to_numeric(df['Quantity'], errors='coerce').sum())
+        except Exception as e:
+            logger.warning(f"Could not compute total items from Quantity column: {e}")
+            self._total_items = 0
 
         logger.info(f"Converted {len(df)} items from {len(orders_list)} orders to DataFrame")
 
@@ -1631,7 +1642,11 @@ class PackerLogic(QObject):
         # Store as packing_list_df and processed_df
         self.packing_list_df = df
         self.processed_df = df.copy()
-        self._total_items = int(pd.to_numeric(df['Quantity'], errors='coerce').sum())
+        try:
+            self._total_items = int(pd.to_numeric(df['Quantity'], errors='coerce').sum())
+        except Exception as e:
+            logger.warning(f"Could not compute total items from Quantity column: {e}")
+            self._total_items = 0
 
         logger.info(f"Converted {len(df)} items from {len(orders_list)} orders to DataFrame")
 

--- a/src/session_lock_manager.py
+++ b/src/session_lock_manager.py
@@ -73,7 +73,7 @@ class SessionLockManager:
         session_dir: Path,
         worker_id: Optional[str] = None,
         worker_name: Optional[str] = None
-    ) -> Tuple[bool, Optional[str]]:
+    ) -> Tuple[bool, Optional[str], Optional[Dict]]:
         """
         Attempt to acquire a lock on the session.
 
@@ -84,9 +84,10 @@ class SessionLockManager:
             worker_name: Worker display name
 
         Returns:
-            Tuple of (success: bool, error_message: Optional[str])
-            - (True, None) if lock acquired successfully
-            - (False, error_message) if session is locked by another process
+            Tuple of (success: bool, error_message: Optional[str], lock_info: Optional[Dict])
+            - (True, None, None) if lock acquired successfully
+            - (False, error_message, lock_info) if session is locked by another process
+              (lock_info is None when the failure is a file I/O error)
 
         Raises:
             IOError: If file operations fail
@@ -107,7 +108,7 @@ class SessionLockManager:
                         extra={"client_id": client_id, "session_dir": str(session_dir)}
                     )
                     self.update_heartbeat(session_dir)
-                    return True, None
+                    return True, None, None
                 else:
                     # Check if lock is stale
                     if self.is_lock_stale(lock_info):
@@ -121,7 +122,7 @@ class SessionLockManager:
                                 "stale_for_minutes": self._get_stale_minutes(lock_info)
                             }
                         )
-                        return False, error_msg
+                        return False, error_msg, lock_info
                     else:
                         # Active lock by another process
                         error_msg = self._format_active_lock_message(lock_info)
@@ -134,7 +135,7 @@ class SessionLockManager:
                                 "attempted_by": self.hostname
                             }
                         )
-                        return False, error_msg
+                        return False, error_msg, lock_info
 
         # Create new lock
         try:
@@ -172,7 +173,7 @@ class SessionLockManager:
                     "user_name": self.username
                 }
             )
-            return True, None
+            return True, None, None
 
         except Exception as e:
             self.logger.error(
@@ -180,7 +181,7 @@ class SessionLockManager:
                 extra={"client_id": client_id, "session_dir": str(session_dir)},
                 exc_info=True
             )
-            return False, f"Failed to create lock file: {e}"
+            return False, f"Failed to create lock file: {e}", None
 
     def release_lock(self, session_dir: Path) -> bool:
         """
@@ -307,9 +308,10 @@ class SessionLockManager:
             try:
                 with open(lock_path, 'r+', encoding='utf-8') as f:
                     # Acquire exclusive lock (Windows only)
+                    _lock_nbytes = max(1, os.fstat(f.fileno()).st_size)
                     if WINDOWS_LOCKING_AVAILABLE:
                         try:
-                            msvcrt.locking(f.fileno(), msvcrt.LK_NBLCK, 1)
+                            msvcrt.locking(f.fileno(), msvcrt.LK_NBLCK, _lock_nbytes)
                         except IOError:
                             # File is locked by another process, retry
                             if attempt < max_retries - 1:
@@ -349,7 +351,7 @@ class SessionLockManager:
                     finally:
                         # Release lock (Windows only)
                         if WINDOWS_LOCKING_AVAILABLE:
-                            msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
+                            msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, _lock_nbytes)
 
             except (IOError, OSError, json.JSONDecodeError) as e:
                 # Network issue or file error - don't crash

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -22,6 +22,8 @@ For small warehouse operations, this module ensures that:
 # Standard library imports
 import os  # For environment variables (PC name)
 import json  # For session info persistence
+import tempfile  # For atomic writes
+import shutil  # For atomic moves
 from pathlib import Path  # Modern path handling
 from datetime import datetime  # Session timestamps
 from typing import Optional  # Type hints
@@ -239,7 +241,7 @@ class SessionManager:
         # - heartbeat: timestamp of last heartbeat update
         # - worker_id: Worker ID (Phase 1.3)
         # - worker_name: Worker display name (Phase 1.3)
-        success, error_msg = self.lock_manager.acquire_lock(
+        success, error_msg, lock_info = self.lock_manager.acquire_lock(
             self.client_id,
             self.output_dir,
             worker_id=self.worker_id,
@@ -247,10 +249,10 @@ class SessionManager:
         )
 
         if not success:
-            # Lock acquisition failed (very rare at this point, but handle it)
-            # This might happen if another process acquired lock in the microseconds
-            # between our check above and this acquisition attempt
             logger.error(f"Failed to acquire session lock: {error_msg}")
+            if lock_info and self.lock_manager.is_lock_stale(lock_info):
+                stale_minutes = self.lock_manager._get_stale_minutes(lock_info)
+                raise StaleLockError(error_msg, lock_info=lock_info, stale_minutes=stale_minutes)
             raise SessionLockedError(error_msg)
 
         # Lock successfully acquired - we now have exclusive access to this session
@@ -276,8 +278,14 @@ class SessionManager:
         }
 
         try:
-            with open(info_path, 'w', encoding='utf-8') as f:
-                json.dump(session_info, f, indent=2)
+            with tempfile.NamedTemporaryFile(
+                mode='w', encoding='utf-8',
+                dir=info_path.parent,
+                delete=False, suffix='.tmp'
+            ) as tmp_file:
+                json.dump(session_info, tmp_file, indent=2)
+                tmp_path = tmp_file.name
+            shutil.move(tmp_path, str(info_path))
             logger.debug(f"Created session info file: {info_path}")
         except Exception as e:
             # Non-critical failure - session can still function
@@ -741,9 +749,15 @@ class SessionManager:
                 session_info['packing_progress'][packing_list_name]['status'] = status
                 session_info['packing_progress'][packing_list_name]['updated_at'] = datetime.now().isoformat()
 
-            # Save updated session info
-            with open(session_info_file, 'w', encoding='utf-8') as f:
-                json.dump(session_info, f, indent=2, ensure_ascii=False)
+            # Save updated session info atomically (temp → move)
+            with tempfile.NamedTemporaryFile(
+                mode='w', encoding='utf-8',
+                dir=session_info_file.parent,
+                delete=False, suffix='.tmp'
+            ) as tmp_file:
+                json.dump(session_info, tmp_file, indent=2, ensure_ascii=False)
+                tmp_path = tmp_file.name
+            shutil.move(tmp_path, str(session_info_file))
 
             logger.info(f"Updated session metadata: {packing_list_name} -> {status}")
 

--- a/tests/test_session_lock_manager.py
+++ b/tests/test_session_lock_manager.py
@@ -81,7 +81,7 @@ def another_lock_manager(mock_profile_manager):
 def test_acquire_lock_success(lock_manager, temp_session_dir):
     """Test acquiring lock on free session."""
     # Acquire lock
-    success, error_msg = lock_manager.acquire_lock("M", temp_session_dir)
+    success, error_msg, _ = lock_manager.acquire_lock("M", temp_session_dir)
 
     # Verify success
     assert success is True
@@ -106,11 +106,11 @@ def test_acquire_lock_success(lock_manager, temp_session_dir):
 def test_acquire_lock_already_locked(lock_manager, another_lock_manager, temp_session_dir):
     """Test acquiring lock when already locked by another PC."""
     # First PC acquires lock
-    success, _ = lock_manager.acquire_lock("M", temp_session_dir)
+    success, _, _ = lock_manager.acquire_lock("M", temp_session_dir)
     assert success is True
 
     # Second PC tries to acquire lock
-    success, error_msg = another_lock_manager.acquire_lock("M", temp_session_dir)
+    success, error_msg, _ = another_lock_manager.acquire_lock("M", temp_session_dir)
 
     # Should fail with error message
     assert success is False
@@ -122,7 +122,7 @@ def test_acquire_lock_already_locked(lock_manager, another_lock_manager, temp_se
 def test_release_lock(lock_manager, temp_session_dir):
     """Test releasing lock."""
     # Acquire lock first
-    success, _ = lock_manager.acquire_lock("M", temp_session_dir)
+    success, _, _ = lock_manager.acquire_lock("M", temp_session_dir)
     assert success is True
 
     lock_path = temp_session_dir / SessionLockManager.LOCK_FILENAME
@@ -209,7 +209,7 @@ def test_heartbeat_timer_starts(lock_manager, temp_session_dir):
     The actual timer would be managed by the application.
     """
     # Acquire lock
-    success, _ = lock_manager.acquire_lock("M", temp_session_dir)
+    success, _, _ = lock_manager.acquire_lock("M", temp_session_dir)
     assert success is True
 
     # Verify heartbeat can be updated
@@ -300,7 +300,7 @@ def test_force_release_stale_lock(lock_manager, temp_session_dir):
     assert not lock_path.exists()
 
     # Should be able to acquire lock now
-    success, _ = lock_manager.acquire_lock("M", temp_session_dir)
+    success, _, _ = lock_manager.acquire_lock("M", temp_session_dir)
     assert success is True
 
 
@@ -324,7 +324,7 @@ def test_fresh_lock_not_stale(lock_manager, temp_session_dir):
 def test_crash_recovery_scenario(lock_manager, temp_session_dir):
     """Test complete crash recovery workflow."""
     # Step 1: Acquire lock
-    success, _ = lock_manager.acquire_lock("M", temp_session_dir)
+    success, _, _ = lock_manager.acquire_lock("M", temp_session_dir)
     assert success is True
 
     # Step 2: Simulate crash - manually set heartbeat to old time
@@ -349,7 +349,7 @@ def test_crash_recovery_scenario(lock_manager, temp_session_dir):
     assert not lock_path.exists()
 
     # Step 5: Reacquire lock (recovery complete)
-    success, _ = lock_manager.acquire_lock("M", temp_session_dir)
+    success, _, _ = lock_manager.acquire_lock("M", temp_session_dir)
     assert success is True
     assert lock_path.exists()
 
@@ -410,7 +410,7 @@ def test_lock_on_read_only_directory(lock_manager, temp_session_dir):
 
     try:
         # Attempt to acquire lock should fail gracefully
-        success, error_msg = lock_manager.acquire_lock("M", temp_session_dir)
+        success, error_msg, _ = lock_manager.acquire_lock("M", temp_session_dir)
 
         assert success is False
         assert error_msg is not None
@@ -423,11 +423,11 @@ def test_lock_on_read_only_directory(lock_manager, temp_session_dir):
 def test_concurrent_lock_attempts(lock_manager, another_lock_manager, temp_session_dir):
     """Test multiple PCs trying to lock simultaneously."""
     # PC1 acquires lock
-    success1, _ = lock_manager.acquire_lock("M", temp_session_dir)
+    success1, _, _ = lock_manager.acquire_lock("M", temp_session_dir)
     assert success1 is True
 
     # PC2 tries to acquire lock (should fail)
-    success2, error_msg2 = another_lock_manager.acquire_lock("M", temp_session_dir)
+    success2, error_msg2, _ = another_lock_manager.acquire_lock("M", temp_session_dir)
     assert success2 is False
     assert error_msg2 is not None
 
@@ -435,7 +435,7 @@ def test_concurrent_lock_attempts(lock_manager, another_lock_manager, temp_sessi
     lock_manager.release_lock(temp_session_dir)
 
     # PC2 can now acquire lock
-    success3, _ = another_lock_manager.acquire_lock("M", temp_session_dir)
+    success3, _, _ = another_lock_manager.acquire_lock("M", temp_session_dir)
     assert success3 is True
 
 
@@ -452,7 +452,7 @@ def test_invalid_lock_file_handling(lock_manager, temp_session_dir):
     assert lock_info is None
 
     # Should be able to acquire lock (overwrites invalid file)
-    success, _ = lock_manager.acquire_lock("M", temp_session_dir)
+    success, _, _ = lock_manager.acquire_lock("M", temp_session_dir)
     assert success is True
 
 
@@ -494,7 +494,7 @@ def test_acquire_lock_with_stale_lock_returns_error(lock_manager, temp_session_d
         json.dump(lock_data, f)
 
     # Try to acquire lock (should fail with stale lock error)
-    success, error_msg = lock_manager.acquire_lock("M", temp_session_dir)
+    success, error_msg, _ = lock_manager.acquire_lock("M", temp_session_dir)
 
     assert success is False
     assert error_msg is not None
@@ -598,11 +598,11 @@ def test_get_stale_minutes_with_missing_heartbeat(lock_manager):
 def test_reacquire_own_lock(lock_manager, temp_session_dir):
     """Test reacquiring lock that we already own."""
     # Acquire lock
-    success1, _ = lock_manager.acquire_lock("M", temp_session_dir)
+    success1, _, _ = lock_manager.acquire_lock("M", temp_session_dir)
     assert success1 is True
 
     # Try to acquire again (should succeed - reacquire own lock)
-    success2, error_msg2 = lock_manager.acquire_lock("M", temp_session_dir)
+    success2, error_msg2, _ = lock_manager.acquire_lock("M", temp_session_dir)
     assert success2 is True
     assert error_msg2 is None
 

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -21,7 +21,7 @@ class TestSessionManager(unittest.TestCase):
 
         # Create mock SessionLockManager
         self.mock_lock_manager = MagicMock()
-        self.mock_lock_manager.acquire_lock.return_value = (True, None)
+        self.mock_lock_manager.acquire_lock.return_value = (True, None, None)
         self.mock_lock_manager.is_locked.return_value = (False, {})
 
         # Create SessionManager with mocks
@@ -43,8 +43,12 @@ class TestSessionManager(unittest.TestCase):
         # Configure mock to return specific session directory
         self.mock_profile_manager.get_session_dir.return_value = expected_dir
 
+        mock_tmp = MagicMock()
+        mock_tmp.return_value.__enter__.return_value.name = '/tmp/fake_session.tmp'
+
         with patch('pathlib.Path.mkdir') as mock_mkdir, \
-             patch('builtins.open', unittest.mock.mock_open()) as mock_open_file, \
+             patch('session_manager.tempfile.NamedTemporaryFile', mock_tmp), \
+             patch('session_manager.shutil.move') as mock_move, \
              patch('json.dump') as mock_json_dump:
 
             self.manager.start_session(test_path)
@@ -58,9 +62,9 @@ class TestSessionManager(unittest.TestCase):
             # Check that lock was acquired
             self.mock_lock_manager.acquire_lock.assert_called_once()
 
-            # Check that the session info file was opened for writing
+            # Check that the session info file was written atomically
             expected_file_path = expected_dir / SESSION_INFO_FILE
-            mock_open_file.assert_called_once_with(expected_file_path, 'w', encoding='utf-8')
+            mock_move.assert_called_once_with('/tmp/fake_session.tmp', str(expected_file_path))
 
             # Verify json.dump was called with correct structure
             call_args = mock_json_dump.call_args


### PR DESCRIPTION
- json_cache: double-checked locking in get() so file I/O runs outside the lock; remove redundant nested lock from _evict_oldest()
- session_lock_manager: acquire_lock now returns (bool, str|None, dict|None) so callers receive lock_info directly on failure
- session_manager: use lock_info from acquire_lock instead of re-calling is_locked(); write session_info.json atomically via temp+move
- main.py: update all four acquire_lock call sites to unpack 3-tuple
- packer_logic: pre-existing simplifications and lookup optimisations

## Summary by Sourcery

Improve thread safety, lock handling, and progress tracking while simplifying packer workflow paths.

Bug Fixes:
- Make JSON cache operations thread-safe using a lock, with TTL measured from insert time and proper eviction and invalidation bookkeeping.
- Ensure Windows lock heartbeat updates lock the full file size instead of a single byte to avoid partial-lock issues.
- Avoid double-normalizing SKUs during scan processing.

Enhancements:
- Perform JSON cache file reads outside the lock with double-checked insertion to reduce contention under concurrent access.
- Return lock_info from session_lock_manager.acquire_lock on failure so callers can classify stale locks without re-reading the lock file.
- Treat stale locks in session_manager.start_session as a distinct error type with stale duration metadata.
- Write session_info.json and session metadata updates atomically via temp-file-and-move to prevent partial JSON writes.
- Precompute total item count and completed items from metadata instead of scanning DataFrames on every state build.
- Use a normalized order lookup map for O(1) order matching on scans instead of per-scan iteration.
- Simplify state and summary file path resolution to always use work_dir root.