### PR TITLE
Fix/xfails

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -33,6 +33,7 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Compile all sources
+        shell: bash
         run: python -m py_compile src/*.py src/session_browser/*.py shared/*.py
 
       - name: Import main module

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,8 +14,6 @@ on:
 
 jobs:
   sanity-check:
-    # Tests were removed for a rewrite (not present in this checkout). Until they're
-    # back, this just checks the source tree compiles and imports cleanly.
     name: Sanity Check
     runs-on: windows-latest
 
@@ -32,6 +30,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Compile all sources
         run: python -m py_compile src/*.py src/session_browser/*.py shared/*.py
@@ -41,6 +40,9 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: python -c "import main"
+
+      - name: Run tests
+        run: python -m pytest
 
   build-windows:
     name: Build Windows Executable

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-qt

--- a/shared/stats_manager.py
+++ b/shared/stats_manager.py
@@ -36,6 +36,7 @@ Usage:
 
 import json
 import os
+import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
@@ -250,10 +251,31 @@ class StatsManager:
                         from shared.metadata_utils import get_current_timestamp
                         stats["last_updated"] = get_current_timestamp()
 
-                        # Save
+                        # Serialize to a throwaway temp file first. If this
+                        # fails partway (disk full, dropped SMB write), only
+                        # the temp file is corrupted — the locked original,
+                        # shared by every PC running Packing/Shopify Tool,
+                        # is never truncated until the new content is known-good.
+                        tmp_fd, tmp_name = tempfile.mkstemp(
+                            dir=self.stats_file.parent,
+                            prefix=f".{self.stats_file.stem}_tmp_",
+                            suffix=self.stats_file.suffix,
+                        )
+                        try:
+                            with os.fdopen(tmp_fd, 'w', encoding='utf-8') as tmp_f:
+                                json.dump(stats, tmp_f, indent=4, ensure_ascii=False)
+                            new_content = Path(tmp_name).read_text(encoding='utf-8')
+                        finally:
+                            try:
+                                os.unlink(tmp_name)
+                            except OSError:
+                                pass
+
+                        # Commit into the locked file only now that the new
+                        # content is fully generated and known-good.
                         f.seek(0)
                         f.truncate()
-                        json.dump(stats, f, indent=4, ensure_ascii=False)
+                        f.write(new_content)
                         f.flush()
                         os.fsync(f.fileno())
 

--- a/src/json_cache.py
+++ b/src/json_cache.py
@@ -29,6 +29,7 @@ Created: 2025-11-26
 Version: 1.0.0
 """
 
+import copy
 import json
 import time
 import threading
@@ -138,7 +139,9 @@ class JSONCache:
                     # Cache hit - update access time for LRU tracking only
                     self._access_times[cache_key] = current_time
                     logger.debug(f"Cache HIT: {file_path.name} (age: {cache_age:.1f}s)")
-                    return self._cache[cache_key]
+                    # Defensive copy: callers must not be able to mutate the
+                    # cached object and poison it for every other reader.
+                    return copy.deepcopy(self._cache[cache_key])
                 else:
                     # Cache expired - remove stale entry
                     logger.debug(f"Cache EXPIRED: {file_path.name} (age: {cache_age:.1f}s)")
@@ -175,7 +178,9 @@ class JSONCache:
                     self._evict_oldest()
                 logger.debug(f"Cache MISS: {file_path.name} loaded and cached")
 
-        return data
+        # Same defensive copy as the cache-hit path: `data` is now also the
+        # object stored in self._cache, so it must not be handed out live.
+        return copy.deepcopy(data)
 
     def _evict_oldest(self):
         """

--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -1,7 +1,5 @@
 # Standard library imports
 import os
-import tempfile
-import shutil
 
 # Third-party imports for data processing
 import pandas as pd  # Excel file handling and data manipulation
@@ -21,6 +19,7 @@ from typing import List, Dict, Any, Tuple
 from logger import get_logger
 from json_cache import get_cached_json, invalidate_json_cache
 from async_state_writer import AsyncStateWriter
+from shared.atomic_write import atomic_write_json
 
 # Initialize module-level logger
 logger = get_logger(__name__)
@@ -224,6 +223,11 @@ class PackerLogic(QObject):
         self.current_order_items_scanned = []  # List of items with scan timestamps
         self.completed_orders_metadata = []  # List of completed orders with timing data
 
+        # Extra items tracking: normalized_sku → extra count (scanned beyond required).
+        # Also initialized BEFORE _load_session_state() so crash-recovered extras
+        # (from '_current_extras') survive a restart instead of being wiped.
+        self.current_extra_items: Dict[str, int] = {}
+
         # Per-order counters for 1.7 metrics — reset by start_order_packing()
         self.current_order_corrections: int = 0           # cancel_item_scan() events
         self.current_order_extra_scan_count: int = 0      # SKU_EXTRA events
@@ -234,9 +238,6 @@ class PackerLogic(QObject):
 
         # Load session state if exists (must come AFTER Phase 2b vars are declared)
         self._load_session_state()
-
-        # Extra items tracking: normalized_sku → extra count (scanned beyond required)
-        self.current_extra_items: Dict[str, int] = {}
 
         # Unknown/incorrect scan tracking: raw barcodes that didn't match any SKU
         self.unknown_scans: List[str] = []
@@ -598,7 +599,9 @@ class PackerLogic(QObject):
 
     def _do_atomic_write(self, state_data: Dict[str, Any]) -> None:
         """
-        Write state_data to disk using an atomic temp-file → rename pattern.
+        Write state_data to disk using the shared atomic (temp-file + rename)
+        helper, with the same retry-on-transient-SMB-error behavior as every
+        other write path in the app.
 
         Called by AsyncStateWriter from a background thread.
         state_data must be a plain serialisable dict (no shared mutable objects).
@@ -610,21 +613,7 @@ class PackerLogic(QObject):
         total_items = state_data.get("progress", {}).get("total_items", 0)
 
         try:
-            state_path = Path(state_file)
-            state_dir = state_path.parent
-
-            with tempfile.NamedTemporaryFile(
-                mode='w',
-                dir=state_dir,
-                prefix='.tmp_state_',
-                suffix='.json',
-                delete=False,
-                encoding='utf-8'
-            ) as tmp_file:
-                json.dump(state_data, tmp_file, indent=2, ensure_ascii=False)
-                tmp_path = tmp_file.name
-
-            shutil.move(tmp_path, state_file)
+            atomic_write_json(state_file, state_data)
             invalidate_json_cache(state_file)
 
             logger.debug(f"Session state saved: {completed_orders_count}/{total_orders} orders, {packed_items}/{total_items} items")
@@ -890,6 +879,7 @@ class PackerLogic(QObject):
             return None, "ORDER_ALREADY_COMPLETED"
 
         self.current_order_number = original_order_number
+        self._unskip_current_order_if_needed()
         items = self.orders_data[original_order_number]['items']
 
         # Capture "is this a brand-new order?" BEFORE potentially adding it to in_progress.
@@ -1974,10 +1964,11 @@ class PackerLogic(QObject):
         if not summary_path:
             summary_path = self._get_summary_file_path()
 
-        # Save to file
+        # Save to file atomically (temp file + rename), same as every other
+        # write path — a failure partway through must never truncate a
+        # previously-good summary in place.
         try:
-            with open(summary_path, 'w', encoding='utf-8') as f:
-                json.dump(summary, f, indent=2, ensure_ascii=False)
+            atomic_write_json(summary_path, summary)
 
             logger.info(f"Session summary (v1.3.0) saved to: {summary_path}")
             return summary_path

--- a/src/profile_manager.py
+++ b/src/profile_manager.py
@@ -53,9 +53,6 @@ class ProfileManager:
         is_network_available (bool): Current network connectivity status
     """
 
-    # Cache for loaded configurations (client_id -> (data, timestamp))
-    _config_cache: Dict[str, Tuple[Dict, datetime]] = {}
-    _sku_cache: Dict[str, Tuple[Dict, datetime]] = {}
     CACHE_TIMEOUT_SECONDS = 60  # Cache valid for 1 minute
 
     def __init__(self, config_path: str = "config.ini"):
@@ -69,6 +66,12 @@ class ProfileManager:
             ProfileManagerError: If configuration is invalid or inaccessible
         """
         logger.info("Initializing ProfileManager...")
+
+        # Cache for loaded configurations (client_id -> (data, timestamp)).
+        # Per-instance (not class-level) so two managers pointed at different
+        # base_path/file servers never share each other's cached data.
+        self._config_cache: Dict[str, Tuple[Dict, datetime]] = {}
+        self._sku_cache: Dict[str, Tuple[Dict, datetime]] = {}
 
         # Load configuration
         self.config = self._load_config(config_path)
@@ -235,7 +238,7 @@ class ProfileManager:
             clients = []
             for d in self.clients_dir.iterdir():
                 if d.is_dir() and d.name.startswith("CLIENT_"):
-                    client_id = d.name.replace("CLIENT_", "")
+                    client_id = d.name[len("CLIENT_"):]
                     clients.append(client_id)
 
             logger.debug(f"Found {len(clients)} clients: {clients}")
@@ -372,7 +375,7 @@ class ProfileManager:
 
             if age_seconds < self.CACHE_TIMEOUT_SECONDS:
                 logger.debug(f"Using cached config for {client_id}")
-                return cached_data
+                return cached_data.copy()
 
         # Load from disk - try packer_config.json first, then fall back to config.json
         packer_config_path = self.clients_dir / f"CLIENT_{client_id}" / "packer_config.json"
@@ -392,7 +395,7 @@ class ProfileManager:
             self._config_cache[cache_key] = (config, datetime.now())
 
             logger.debug(f"Loaded config for client {client_id} from {path_to_use.name}")
-            return config
+            return config.copy()
 
         except Exception as e:
             logger.error(f"Error loading config for {client_id}: {e}")
@@ -559,13 +562,10 @@ class ProfileManager:
                         # Read current data
                         f.seek(0)
                         current_data = json.load(f)
-                        current_mappings = current_data.get('sku_mapping', {})
 
-                        # Merge: new mappings override existing
-                        current_mappings.update(mappings)
-
-                        # Update config with new mappings
-                        current_data['sku_mapping'] = current_mappings
+                        # Replace (not merge): callers pass the full desired mapping,
+                        # so a deleted entry must not survive by merging onto disk.
+                        current_data['sku_mapping'] = mappings
                         current_data['last_updated'] = datetime.now().isoformat()
                         current_data['updated_by'] = os.environ.get('COMPUTERNAME', 'Unknown')
 
@@ -626,12 +626,9 @@ class ProfileManager:
                 with open(packer_config_path, 'r', encoding='utf-8') as f:
                     current_config = json.load(f)
 
-            # Get current mappings and merge
-            current_mappings = current_config.get('sku_mapping', {})
-            current_mappings.update(mappings)
-
-            # Update config
-            current_config['sku_mapping'] = current_mappings
+            # Replace (not merge): callers pass the full desired mapping, so a
+            # deleted entry must not survive by merging onto disk.
+            current_config['sku_mapping'] = mappings
             current_config['last_updated'] = datetime.now().isoformat()
             current_config['updated_by'] = os.environ.get('COMPUTERNAME', 'Unknown')
 

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -23,10 +23,10 @@ For small warehouse operations, this module ensures that:
 import os  # For environment variables (PC name)
 import json  # For session info persistence
 from pathlib import Path  # Modern path handling
-from datetime import datetime  # Session timestamps
 from typing import Optional  # Type hints
 
 from shared.atomic_write import atomic_write_json
+from shared.metadata_utils import get_current_timestamp
 
 # Local imports
 from logger import get_logger
@@ -269,7 +269,7 @@ class SessionManager:
         session_info = {
             'client_id': self.client_id,
             'packing_list_path': self.packing_list_path,
-            'started_at': datetime.now().isoformat(),  # ISO format for parsing
+            'started_at': get_current_timestamp(),  # timezone-aware ISO format for parsing
             'pc_name': os.environ.get('COMPUTERNAME', 'Unknown')  # Windows PC name
         }
 
@@ -700,12 +700,12 @@ class SessionManager:
             # Update for this packing list
             if packing_list_name not in session_info['packing_progress']:
                 session_info['packing_progress'][packing_list_name] = {
-                    'started_at': datetime.now().isoformat(),
+                    'started_at': get_current_timestamp(),
                     'status': status
                 }
             else:
                 session_info['packing_progress'][packing_list_name]['status'] = status
-                session_info['packing_progress'][packing_list_name]['updated_at'] = datetime.now().isoformat()
+                session_info['packing_progress'][packing_list_name]['updated_at'] = get_current_timestamp()
 
             # Save updated session info atomically (temp → move)
             atomic_write_json(session_info_file, session_info, indent=2, ensure_ascii=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,7 @@ Design notes:
   config falls back to a hardcoded Windows UNC path
   (\\\\192.168.88.101\\_Fulfilment_\\0UFulfilment) which, on POSIX, is
   treated as a single literal directory name and gets created in the repo
-  root the first time any module calls get_logger(). See test_logger.py
-  for a regression test that documents this directly.
+  root the first time any module calls get_logger().
 """
 import os
 import sys
@@ -39,20 +38,6 @@ def qapp():
     """A QApplication is required for QObject subclasses with Signals (PackerLogic)."""
     app = QApplication.instance() or QApplication([])
     yield app
-
-
-@pytest.fixture(autouse=True)
-def _isolate_profile_manager_caches():
-    """ProfileManager._config_cache/_sku_cache are class-level (shared across all
-    instances in the process) — see test_profile_manager.py::test_config_cache_leaks_across_instances
-    for why that itself is a bug. Clear them around every test so unrelated tests
-    don't pollute each other via the same client_id.
-    """
-    ProfileManager._config_cache.clear()
-    ProfileManager._sku_cache.clear()
-    yield
-    ProfileManager._config_cache.clear()
-    ProfileManager._sku_cache.clear()
 
 
 @pytest.fixture

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -1,23 +1,24 @@
-"""File save/write correctness (target #7) and the inconsistencies between
-save paths across the codebase (target #6).
+"""File save/write correctness (target #7) across the codebase (target #6).
 
 shared/atomic_write.py::atomic_write_json is the "reference" implementation:
 temp file in the same directory + atomic rename, with retries for transient
 SMB errors. session_manager.py, session_lock_manager.py,
-session_registry_manager.py and shared/worker_manager.py all use it. This
-file verifies that reference implementation, then contrasts it against the
-save paths that DON'T use it even though they write to the same kind of
+session_registry_manager.py and shared/worker_manager.py all use it directly.
+This file verifies that reference implementation, then verifies the save
+paths that used to diverge from it despite writing to the same kind of
 network share: PackerLogic._do_atomic_write (packing_state.json — the
-highest-frequency write in the app), PackerLogic.save_session_summary
-(session_summary.json), and StatsManager._atomic_update (global_stats.json,
-shared between Packing Tool and Shopify Tool).
+highest-frequency write in the app) and PackerLogic.save_session_summary
+(session_summary.json) now both delegate to it; StatsManager._atomic_update
+(global_stats.json, shared between Packing Tool and Shopify Tool) can't
+delegate to it directly (it needs the advisory lock held across the whole
+read-modify-write, not just the final write), so it gets the same
+temp-file-first crash-safety applied to its own locked-write step instead.
 """
 import json
 from pathlib import Path
 
 import pytest
 
-import packer_logic
 from shared.atomic_write import atomic_write_json
 from shared.stats_manager import StatsManager, StatsManagerError
 
@@ -73,38 +74,42 @@ def test_atomic_write_json_raises_after_exhausting_retries_but_keeps_original_in
 
 
 # ---------------------------------------------------------------------------
-# PackerLogic._do_atomic_write — atomic (temp file + shutil.move), but with
-# no retry, unlike atomic_write_json — despite writing the highest-frequency
-# file in the whole app (packing_state.json, saved on every scan).
+# Regression test: PackerLogic._do_atomic_write used to hand-roll its own
+# temp-file + shutil.move with no retry, unlike atomic_write_json — despite
+# writing the highest-frequency file in the whole app (packing_state.json,
+# saved on every scan). It now delegates to atomic_write_json directly, so
+# it gets the same retry-on-transient-SMB-error behavior as every other
+# write path.
 # ---------------------------------------------------------------------------
 
-def test_packer_logic_state_write_has_no_retry_on_transient_failure(loaded_logic, monkeypatch):
+def test_packer_logic_state_write_retries_transient_failures_like_every_other_write_path(loaded_logic, monkeypatch):
     calls = {"n": 0}
+    real_replace = Path.replace
 
-    def always_fail(src, dst):
+    def flaky_replace(self, dst):
         calls["n"] += 1
-        raise OSError("simulated transient SMB error")
+        if calls["n"] < 3:
+            raise OSError("simulated transient SMB error")
+        return real_replace(self, dst)
 
-    monkeypatch.setattr(packer_logic.shutil, "move", always_fail)
+    monkeypatch.setattr(Path, "replace", flaky_replace)
+    monkeypatch.setattr("shared.atomic_write.time.sleep", lambda s: None)
 
     state = loaded_logic._build_state_dict()
-    loaded_logic._do_atomic_write(state)  # caught internally, never raises...
+    loaded_logic._do_atomic_write(state)
 
-    assert calls["n"] == 1  # ...but also never retried, unlike atomic_write_json's default retries=3
-    # The scan that produced this state is now unrecorded on disk with no
-    # retry and no surfaced error — only a log line. If the very next write
-    # attempt for a *different* state also transiently fails, this scan's
-    # data is gone for good (AsyncStateWriter only keeps the latest pending
-    # write, it does not queue every write).
+    assert calls["n"] == 3  # failed twice, succeeded on the 3rd attempt
 
 
 # ---------------------------------------------------------------------------
-# PackerLogic.save_session_summary — not atomic at all: plain open('w') +
-# json.dump, no temp file. A failure partway through truncates the
-# destination in place.
+# Regression test: PackerLogic.save_session_summary used to write with a
+# plain open('w') + json.dump, no temp file — a failure partway through
+# truncated the destination in place. It now goes through atomic_write_json
+# like every other write path, so the previously-good summary must survive
+# a failed save untouched.
 # ---------------------------------------------------------------------------
 
-def test_save_session_summary_corrupts_file_in_place_on_write_failure(loaded_logic, monkeypatch):
+def test_save_session_summary_does_not_corrupt_file_on_write_failure(loaded_logic, monkeypatch):
     summary_path = loaded_logic.work_dir / "session_summary.json"
     summary_path.write_text('{"previous": "good summary"}', encoding="utf-8")
 
@@ -112,29 +117,33 @@ def test_save_session_summary_corrupts_file_in_place_on_write_failure(loaded_log
         fp.write('{"truncated')  # simulate a write that dies partway through
         raise OSError("disk full")
 
-    monkeypatch.setattr(packer_logic.json, "dump", failing_dump)
+    monkeypatch.setattr("shared.atomic_write.json.dump", failing_dump)
+    monkeypatch.setattr("shared.atomic_write.time.sleep", lambda s: None)
 
     with pytest.raises(IOError):
         loaded_logic.save_session_summary()
 
-    # Unlike atomic_write_json, this leaves a half-written, invalid JSON file
-    # in place of the previously-good summary — there is no temp file to fall
-    # back to.
+    # The failing write only ever touches a temp file — the previously-good
+    # destination is untouched, and the temp file is cleaned up.
     content = summary_path.read_text(encoding="utf-8")
-    assert content != '{"previous": "good summary"}'
-    with pytest.raises(json.JSONDecodeError):
-        json.loads(content)
+    assert content == '{"previous": "good summary"}'
+    assert not list(summary_path.parent.glob(".*_tmp_*"))
 
 
 # ---------------------------------------------------------------------------
-# StatsManager._atomic_update — the name promises atomicity, but it only
-# provides *concurrency* safety (advisory file lock held across read-modify-
-# write); it truncates the file in place before writing, so it is not
-# crash-safe. global_stats.json is shared by BOTH Shopify Tool and Packing
-# Tool — a single corrupted write loses history recorded by every PC.
+# Regression test: StatsManager._atomic_update's name promised atomicity, but
+# it only provided *concurrency* safety (advisory file lock held across
+# read-modify-write); it used to truncate the file in place before writing,
+# so it was not crash-safe. global_stats.json is shared by BOTH Shopify Tool
+# and Packing Tool — a single corrupted write would lose history recorded by
+# every PC. It now serializes to a throwaway temp file first and only
+# truncates the locked original once the new content is known-good, while
+# still holding the same advisory lock the whole time (required since
+# renaming a new file over the locked path would break that lock's
+# cross-process guarantee).
 # ---------------------------------------------------------------------------
 
-def test_stats_manager_atomic_update_is_not_actually_crash_safe(tmp_path, monkeypatch):
+def test_stats_manager_atomic_update_is_actually_crash_safe(tmp_path, monkeypatch):
     manager = StatsManager(str(tmp_path), max_retries=2, retry_delay=0)
     manager.record_packing(client_id="M", session_id="s1", worker_id="w1", orders_count=5, items_count=10)
     assert json.loads(manager.stats_file.read_text(encoding="utf-8"))["total_orders_packed"] == 5
@@ -148,8 +157,8 @@ def test_stats_manager_atomic_update_is_not_actually_crash_safe(tmp_path, monkey
     with pytest.raises(StatsManagerError):
         manager.record_packing(client_id="M", session_id="s2", worker_id="w1", orders_count=1, items_count=1)
 
-    # The file was truncated (f.seek(0); f.truncate()) before the failing
-    # write, wiping the previously-good record with no way back.
-    corrupted = manager.stats_file.read_text(encoding="utf-8")
-    with pytest.raises(json.JSONDecodeError):
-        json.loads(corrupted)
+    # The failing write only ever touched a temp file — the previously-good
+    # record must survive intact, and no temp file is left behind.
+    preserved = json.loads(manager.stats_file.read_text(encoding="utf-8"))
+    assert preserved["total_orders_packed"] == 5
+    assert not list(manager.stats_file.parent.glob(".*_tmp_*"))

--- a/tests/test_json_cache.py
+++ b/tests/test_json_cache.py
@@ -95,24 +95,14 @@ def test_eviction_keeps_cache_at_or_under_max_size(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# BUG: get() hands back the live object stored in the cache, not a copy.
-# Any caller that mutates what it gets back corrupts the cache for every
-# other reader of that same path — without ever writing to disk. This is the
-# root cause behind PackerLogic silently poisoning cross-consumer reads of
-# packing_state.json (see test_packer_logic_state_persistence.py).
+# Regression test: get() used to hand back the live object stored in the
+# cache, not a copy. Any caller that mutated what it got back corrupted the
+# cache for every other reader of that same path — without ever writing to
+# disk. This was the root cause behind PackerLogic silently poisoning
+# cross-consumer reads of packing_state.json (see
+# test_packer_logic_state_persistence.py).
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: JSONCache.get() returns the exact object it stores internally "
-        "(`return self._cache[cache_key]` / `return data` on miss), not a "
-        "defensive copy. A caller that treats the result as a local, mutable "
-        "value (a very ordinary Python pattern) silently corrupts what every "
-        "other reader of the same file path sees for the rest of the TTL "
-        "window, with no write to disk involved at all."
-    ),
-    strict=True,
-)
 def test_get_does_not_return_a_reference_callers_can_use_to_poison_the_cache(tmp_path):
     path = tmp_path / "data.json"
     path.write_text(json.dumps({"in_progress": {"ORDER-1": []}}), encoding="utf-8")

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -63,18 +63,15 @@ def test_parse_timestamp_none_and_empty_return_none():
 
 
 # ---------------------------------------------------------------------------
-# Cross-module inconsistency: session_manager.update_session_metadata() writes
-# naive timestamps (`datetime.now().isoformat()`), while the rest of the app's
-# convention (metadata_utils.get_current_timestamp) is always timezone-aware.
+# Regression test: session_manager.update_session_metadata() used to write
+# naive timestamps (`datetime.now().isoformat()`), while the rest of the
+# app's convention (metadata_utils.get_current_timestamp) is always
+# timezone-aware. Naive `started_at`/`updated_at` values fed into
+# parse_timestamp()/calculate_duration() (which assume naive == UTC) would be
+# wrong by the local UTC offset on any machine not running in UTC.
 # ---------------------------------------------------------------------------
 
-def test_session_manager_metadata_timestamps_are_naive_unlike_the_rest_of_the_app(tmp_path):
-    """Documents a real inconsistency: if these naive `started_at`/`updated_at`
-    values are ever fed into parse_timestamp()/calculate_duration() (which
-    assume naive == UTC), results will be wrong by the local UTC offset on any
-    machine not running in UTC — the opposite convention from
-    get_current_timestamp() used everywhere else for durations/metrics.
-    """
+def test_session_manager_metadata_timestamps_are_timezone_aware_like_the_rest_of_the_app(tmp_path):
     import session_manager
 
     session_info_path = tmp_path / "session_info.json"
@@ -86,11 +83,9 @@ def test_session_manager_metadata_timestamps_are_naive_unlike_the_rest_of_the_ap
     saved = json.loads(session_info_path.read_text(encoding="utf-8"))
     started_at = saved["packing_progress"]["DHL_Orders"]["started_at"]
 
-    aware_ts = get_current_timestamp()
-    assert "+" not in started_at and not started_at.endswith("Z"), (
-        "expected update_session_metadata()'s timestamp to be naive (current "
-        "behavior); this now looks tz-aware like get_current_timestamp() "
-        f"({aware_ts!r}) — if so the inconsistency was fixed, update this test"
+    assert "+" in started_at or started_at.endswith("Z"), (
+        "expected update_session_metadata()'s timestamp to be timezone-aware "
+        f"like get_current_timestamp(), got {started_at!r}"
     )
 
 

--- a/tests/test_packer_logic_scanning.py
+++ b/tests/test_packer_logic_scanning.py
@@ -5,7 +5,6 @@ force_confirm_item / skip_order / confirm_keep_extra / remove_extra_item, and
 the all_orders_complete signal — the exact sequence a warehouse worker drives
 via barcode scans.
 """
-import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -297,20 +296,11 @@ def test_skip_order_preserves_progress_for_resume(loaded_logic):
     assert loaded_logic.current_order_state[0]["packed"] == 1
 
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: start_order_packing() never calls _unskip_current_order_if_needed() "
-        "(only full completion does — see process_sku_scan/force_confirm_item/"
-        "_maybe_complete_after_extra_resolution). An order that was skipped and is "
-        "then resumed but not yet re-completed stays in skipped_orders. "
-        "session_browser/orders_tab.py._load_orders() renders anything in "
-        "skipped_orders as a grey '[SKIPPED]' row and never cross-checks in_progress, "
-        "so a resumed order with real partial packing progress is displayed as "
-        "skipped/abandoned to anyone viewing the Session Browser while it's being "
-        "actively worked on."
-    ),
-    strict=True,
-)
+# Regression test: start_order_packing() used to never call
+# _unskip_current_order_if_needed() (only full completion did). An order that
+# was skipped and then resumed but not yet re-completed stayed in
+# skipped_orders, so session_browser/orders_tab.py._load_orders() rendered it
+# as a grey '[SKIPPED]' row even while it was being actively re-packed.
 def test_resuming_a_skipped_order_should_clear_it_from_the_skipped_list(loaded_logic):
     loaded_logic.start_order_packing("ORDER-001")
     loaded_logic.skip_order()

--- a/tests/test_packer_logic_state_persistence.py
+++ b/tests/test_packer_logic_state_persistence.py
@@ -9,8 +9,6 @@ PackerLogic._do_atomic_write), not a stubbed writer.
 import json
 import copy
 
-import pytest
-
 from json_cache import get_cached_json, invalidate_json_cache
 
 
@@ -137,27 +135,17 @@ def test_corrupted_json_state_file_starts_fresh_instead_of_crashing(packer_logic
 
 
 # ---------------------------------------------------------------------------
-# BUG: pending extra-item flags are silently lost across a crash/restart.
+# Regression test: pending extra-item flags used to be silently lost across
+# a crash/restart.
 #
-# PackerLogic.__init__ does:
+# PackerLogic.__init__ used to do:
 #     self._load_session_state()                        # restores current_extra_items from disk
-#     self.current_extra_items: Dict[str, int] = {}      # ...then immediately wipes it again
-# So `_current_extras` round-trips to disk correctly but is dead on read:
-# whatever _load_session_state() restored is discarded two lines later in the
-# same constructor, every single time.
+#     self.current_extra_items: Dict[str, int] = {}      # ...then immediately wiped it again
+# So `_current_extras` round-tripped to disk correctly but was dead on read:
+# whatever _load_session_state() restored was discarded two lines later in
+# the same constructor, every single time.
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: in PackerLogic.__init__, `self.current_extra_items: Dict[str, int] = {}` "
-        "runs immediately AFTER `self._load_session_state()`, unconditionally wiping "
-        "out whatever current_extra_items the latter just restored from "
-        "'_current_extras' in packing_state.json. The restoration code (and its "
-        "'crash recovery' comment) is dead — pending extras never survive a restart, "
-        "regardless of which order is resumed."
-    ),
-    strict=True,
-)
 def test_unresolved_extras_survive_a_restart(packer_logic_factory, session_factory):
     orders = [("ORDER-A", "DHL", [
         {"sku": "SKU-1", "quantity": 1, "product_name": "A1"},
@@ -191,26 +179,13 @@ def test_unresolved_extras_survive_a_restart(packer_logic_factory, session_facto
 
 
 # ---------------------------------------------------------------------------
-# BUG: get_cached_json() hands out the live cached object by reference.
-# _load_session_state() mutates item dicts in place (legacy-field migration),
-# which silently poisons the shared process-wide JSON cache for every other
-# reader of the same path (e.g. Session Browser) without ever writing to disk.
+# Regression test: get_cached_json() used to hand out the live cached object
+# by reference. _load_session_state() mutates item dicts in place
+# (legacy-field migration), which used to silently poison the shared
+# process-wide JSON cache for every other reader of the same path (e.g.
+# Session Browser) without ever writing to disk.
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: json_cache.JSONCache.get() returns the exact object stored in its "
-        "internal cache dict (no copy), and PackerLogic._load_session_state() "
-        "mutates item_state dicts in place while migrating legacy fields "
-        "(original_sku/normalized_sku/packed/required/row) and later while "
-        "scanning (found_item['packed'] += 1). Because those dicts ARE the cached "
-        "object, every in-memory scan mutates the global JSON cache before the "
-        "corresponding write ever reaches disk, and if the write then fails, the "
-        "cache is left silently reporting the unwritten state as if it were "
-        "confirmed on disk (invalidate_json_cache() only runs on the success path)."
-    ),
-    strict=True,
-)
 def test_json_cache_is_not_mutated_by_in_memory_migration(packer_logic_factory, session_factory):
     orders = [("ORDER-001", "DHL", [{"sku": "SKU-AAA", "quantity": 2, "product_name": "Widget"}])]
     session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -92,24 +92,14 @@ def test_load_client_config_missing_client_returns_none(profile_manager):
 
 
 # ---------------------------------------------------------------------------
-# BUG: load_client_config's cache-hit path returns the live cached dict by
-# reference (no .copy()) — inconsistent with load_sku_mapping, which always
-# .copy()s. A caller that does `cfg = load_client_config(...); cfg['x'] = y`
-# for local-only processing silently corrupts the class-level cache for every
-# other reader of that client's config for up to CACHE_TIMEOUT_SECONDS,
-# without ever touching disk.
+# Regression test: load_client_config's cache-hit (and cache-miss) path used
+# to return the live cached dict by reference (no .copy()) — inconsistent
+# with load_sku_mapping, which always .copy()s. A caller doing
+# `cfg = load_client_config(...); cfg['x'] = y` for local-only processing
+# used to silently corrupt the cache for every other reader of that client's
+# config for up to CACHE_TIMEOUT_SECONDS, without ever touching disk.
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: ProfileManager.load_client_config() caches and returns the same "
-        "dict object (both on cache-miss and cache-hit) instead of a defensive "
-        "copy, unlike load_sku_mapping() which always returns .copy(). Any "
-        "caller mutating the returned config for local use corrupts the shared "
-        "class-level cache."
-    ),
-    strict=True,
-)
 def test_load_client_config_does_not_leak_mutations_into_the_cache(profile_manager):
     profile_manager.create_client_profile("M", "M Cosmetics")
     config = profile_manager.load_client_config("M")
@@ -120,24 +110,15 @@ def test_load_client_config_does_not_leak_mutations_into_the_cache(profile_manag
 
 
 # ---------------------------------------------------------------------------
-# BUG: _config_cache / _sku_cache are class-level attributes, not per-instance
-# — every ProfileManager in the process shares one cache keyed only by
-# client_id, with no base_path in the key. Two ProfileManager instances
-# pointed at two different file servers (e.g. dev vs prod config, or the app
-# reloading config.ini after the user changes FileServerPath) but with the
-# same client_id will leak each other's cached config/SKU data.
+# Regression test: _config_cache / _sku_cache used to be class-level
+# attributes, not per-instance — every ProfileManager in the process shared
+# one cache keyed only by client_id, with no base_path in the key. Two
+# ProfileManager instances pointed at two different file servers (e.g. dev
+# vs prod config, or the app reloading config.ini after the user changes
+# FileServerPath) but with the same client_id used to leak each other's
+# cached config/SKU data.
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: ProfileManager._config_cache/_sku_cache are class attributes "
-        "(`Dict[...] = {}` on the class body), shared across every instance in "
-        "the process regardless of base_path. A second ProfileManager pointed "
-        "at a different file server root, but with the same client_id, gets "
-        "the first instance's cached data instead of reading its own disk."
-    ),
-    strict=True,
-)
 def test_config_cache_does_not_leak_across_instances_with_different_base_paths(tmp_path):
     import configparser
 
@@ -161,24 +142,13 @@ def test_config_cache_does_not_leak_across_instances_with_different_base_paths(t
 
 
 # ---------------------------------------------------------------------------
-# BUG: save_sku_mapping MERGES onto whatever is already on disk
-# (current_mappings.update(mappings)) instead of replacing it. The SKU
-# Mapping dialog's delete button removes an entry from its local dict and
+# Regression test: save_sku_mapping used to MERGE onto whatever was already
+# on disk (current_mappings.update(mappings)) instead of replacing it. The
+# SKU Mapping dialog's delete button removes an entry from its local dict and
 # calls save_sku_mapping() with the reduced map, expecting a full replace —
-# but the merge means a deleted mapping is silently restored on next load.
+# the merge meant a deleted mapping was silently restored on next load.
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: ProfileManager.save_sku_mapping() merges the given mapping onto "
-        "the existing on-disk mapping (current_mappings.update(mappings)) "
-        "rather than replacing it. sku_mapping_dialog.py's delete flow saves "
-        "the full reduced dict expecting a replace-semantics save, so deleted "
-        "barcode->SKU mappings silently reappear on the next load — users "
-        "cannot actually delete a SKU mapping."
-    ),
-    strict=True,
-)
 def test_save_sku_mapping_can_delete_an_entry(profile_manager):
     profile_manager.create_client_profile("M", "M Cosmetics")
     profile_manager.save_sku_mapping("M", {"BARCODE-A": "SKU-A", "BARCODE-B": "SKU-B"})
@@ -216,22 +186,15 @@ def test_load_sku_mapping_cache_hit_returns_a_copy_not_the_cached_object(profile
 
 
 # ---------------------------------------------------------------------------
-# BUG: get_available_clients() and list_clients() are near-duplicate
-# functions meant to do the same thing but diverge on a valid client_id.
+# Regression test: get_available_clients() and list_clients() are
+# near-duplicate functions meant to do the same thing but used to diverge on
+# a valid client_id. get_available_clients() used to strip the 'CLIENT_'
+# prefix with str.replace('CLIENT_', ''), which removes EVERY occurrence of
+# that substring, not just the leading one, disagreeing with list_clients()'s
+# dir_name[7:] slice for a client_id that legitimately contains 'CLIENT_'
+# after the first character.
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: get_available_clients() strips the 'CLIENT_' prefix with "
-        "str.replace('CLIENT_', ''), which removes EVERY occurrence of that "
-        "substring, not just the leading one. list_clients() correctly slices "
-        "off exactly the first 7 characters (dir_name[7:]). A client_id that "
-        "legitimately contains 'CLIENT_' after the first character (allowed: "
-        "validate_client_id only rejects an id that *starts* with 'CLIENT_') "
-        "makes the two functions disagree."
-    ),
-    strict=True,
-)
 def test_get_available_clients_and_list_clients_agree(profile_manager):
     client_id = "XCLIENT_Y"  # valid per validate_client_id: doesn't start with CLIENT_
     is_valid, msg = ProfileManager.validate_client_id(client_id)


### PR DESCRIPTION
## Summary by Sourcery

Align file-writing, caching, and metadata behavior across the app and turn previous xfail-documented bugs into passing regression tests, while re-enabling tests in CI.

Bug Fixes:
- Make PackerLogic state and session summary writes use the shared atomic_write_json helper with transient SMB retries and crash-safe temp-file semantics.
- Ensure StatsManager._atomic_update is crash-safe by writing through a temp file while preserving its advisory locking guarantees.
- Preserve unresolved extra-item state across restarts by initializing current_extra_items before loading session state.
- Prevent JSON cache consumers from poisoning shared state by returning deep copies instead of live cached objects.
- Stop ProfileManager config/SKU caches from leaking across instances and guard them by returning copies of cached configs.
- Allow SKU mappings to be truly deletable by replacing on-disk mappings instead of merging into existing data.
- Make get_available_clients and list_clients agree on client IDs by using consistent prefix stripping.
- Fix session metadata timestamps to be timezone-aware using the shared metadata_utils convention.
- Ensure resuming a skipped order clears it from the skipped list for accurate Session Browser display.

Enhancements:
- Refine tests to convert previously xfail-documented bugs into positive regression tests for the fixed behaviors.
- Tighten atomic write tests to exercise transient failure retries and temp-file-only corruption scenarios.
- Clarify docstrings and comments around crash safety, caching, and timestamp semantics to reflect the new guarantees.

Build:
- Add requirements-dev.txt and have the CI workflow install it.
- Update the CI windows sanity-check job to run the pytest suite in addition to import/compile checks.

CI:
- Extend the GitHub Actions build-release workflow to install dev dependencies and execute tests as part of the sanity-check job.

Tests:
- Replace xfail bug-documentation tests with passing regression tests across atomic writes, profile caching, JSON cache behavior, session persistence, scanning, and metadata utilities.
- Adjust test fixtures now that ProfileManager caches are per-instance rather than class-level shared state.