### PR TITLE
ci: add blocking ruff lint gate

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -32,6 +32,9 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
+      - name: Lint (ruff)
+        run: ruff check .
+
       - name: Compile all sources
         shell: bash
         run: python -m py_compile src/*.py src/session_browser/*.py shared/*.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-qt
+ruff~=0.16.0

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,15 @@
+# Project-wide rule decisions, on top of ruff's defaults.
+[lint]
+ignore = [
+    # Codebase idiom: warehouse-floor GUI, so most I/O and Qt-callback sites
+    # deliberately catch broad Exception at a boundary (worker thread, cleanup
+    # handler, best-effort cache read) rather than crash the app. Narrowing
+    # each to a specific exception type would guess at failure modes we can't
+    # verify and would weaken the "must not crash" guarantee these guards exist for.
+    "BLE001",
+]
+
+[lint.flake8-bugbear]
+# QModelIndex() is an immutable value type (Qt's standard "no parent" sentinel),
+# so using it as a default argument is safe despite the general mutable-default footgun.
+extend-immutable-calls = ["PySide6.QtCore.QModelIndex"]

--- a/run_dev.py
+++ b/run_dev.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Local dev runner: launches Packer's Assistant against the shared dev-server
 used by shopify-fulfillment-tool (sibling repo), instead of the production
 network share in config.ini.
@@ -38,5 +37,6 @@ AutoRefreshInterval = 0
 
 if __name__ == "__main__":
     subprocess.run(
-        [sys.executable, str(ROOT / "src" / "main.py"), "--config", str(CONFIG_DEV)]
+        [sys.executable, str(ROOT / "src" / "main.py"), "--config", str(CONFIG_DEV)],
+        check=False,
     )

--- a/run_dev.py
+++ b/run_dev.py
@@ -36,7 +36,8 @@ AutoRefreshInterval = 0
 """)
 
 if __name__ == "__main__":
-    subprocess.run(
+    result = subprocess.run(
         [sys.executable, str(ROOT / "src" / "main.py"), "--config", str(CONFIG_DEV)],
         check=False,
     )
+    sys.exit(result.returncode)

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -11,9 +11,9 @@ from .file_lock import FileLockError
 from .stats_manager import StatsManager, StatsManagerError
 
 __all__ = [
+    'FileLockError',
     'StatsManager',
     'StatsManagerError',
-    'FileLockError',
 ]
 
 __version__ = '2.0.0'

--- a/shared/atomic_write.py
+++ b/shared/atomic_write.py
@@ -1,9 +1,12 @@
 """Atomic JSON writes (temp file + rename) for files on shared network storage."""
 import json
+import logging
 import os
 import tempfile
 import time
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def atomic_write_json(path, data, *, indent=2, ensure_ascii=False, retries=3, retry_delay=0.15):
@@ -36,8 +39,8 @@ def atomic_write_json(path, data, *, indent=2, ensure_ascii=False, retries=3, re
             if tmp_path and tmp_path.exists():
                 try:
                     tmp_path.unlink()
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(f"Could not remove temp file {tmp_path}: {e}")
             if attempt < retries - 1:
                 time.sleep(retry_delay)
 

--- a/shared/file_lock.py
+++ b/shared/file_lock.py
@@ -1,4 +1,5 @@
 """Cross-platform advisory file locking for shared JSON files on network storage."""
+import logging
 import time
 from contextlib import contextmanager
 
@@ -13,6 +14,8 @@ try:
     UNIX_LOCKING_AVAILABLE = True
 except ImportError:
     UNIX_LOCKING_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
 
 
 class FileLockError(Exception):
@@ -68,21 +71,20 @@ def locked_file(file_handle, timeout: float = 5.0, retry_delay: float = 0.1):
                     msvcrt.locking(file_handle.fileno(), msvcrt.LK_UNLCK, 1)
                 elif UNIX_LOCKING_AVAILABLE:
                     fcntl.flock(file_handle.fileno(), fcntl.LOCK_UN)
-            except Exception:
-                pass  # Ignore unlock errors
+            except Exception as e:
+                logger.debug(f"Ignoring unlock error: {e}")
 
 
 if __name__ == "__main__":
-    import tempfile
     import os
+    import tempfile
 
     with tempfile.NamedTemporaryFile(mode='w+', delete=False) as tmp:
         tmp_path = tmp.name
 
     try:
-        with open(tmp_path, 'r+') as f:
-            with locked_file(f):
-                f.write("locked ok")
+        with open(tmp_path, 'r+') as f, locked_file(f):
+            f.write("locked ok")
         with open(tmp_path) as f:
             assert f.read() == "locked ok"
         print("file_lock self-check OK")

--- a/shared/logger.py
+++ b/shared/logger.py
@@ -52,7 +52,7 @@ class UnifiedJSONFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         log_data = {
-            "timestamp": datetime.fromtimestamp(record.created).isoformat(),
+            "timestamp": datetime.fromtimestamp(record.created).astimezone().isoformat(),
             "level": record.levelname,
             "tool": self.tool_name,
             "module": record.module,

--- a/shared/metadata_utils.py
+++ b/shared/metadata_utils.py
@@ -11,7 +11,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ def get_current_timestamp() -> str:
     return datetime.now().astimezone().isoformat()
 
 
-def parse_timestamp(timestamp_str: str) -> Optional[datetime]:
+def parse_timestamp(timestamp_str: str) -> datetime | None:
     """Parse ISO timestamp to datetime object
 
     Handles both timezone-aware and timezone-naive timestamps for
@@ -99,7 +99,7 @@ def calculate_duration(start: str, end: str) -> int:
     return int((end_dt - start_dt).total_seconds())
 
 
-def load_session_summary(path: Path) -> Dict[str, Any]:
+def load_session_summary(path: Path) -> dict[str, Any]:
     """Load session summary in v1.3.0 format
 
     Args:
@@ -124,8 +124,8 @@ def load_session_summary(path: Path) -> Dict[str, Any]:
     try:
         with open(path, 'r', encoding='utf-8') as f:
             data = json.load(f)
-    except json.JSONDecodeError as e:
-        logger.error(f"Corrupted session summary at {path}: {e}", exc_info=True)
+    except json.JSONDecodeError:
+        logger.exception(f"Corrupted session summary at {path}")
         raise
 
     # Check version
@@ -140,7 +140,7 @@ def load_session_summary(path: Path) -> Dict[str, Any]:
     return validated
 
 
-def _validate_v1_3_0_format(data: Dict[str, Any]) -> Dict[str, Any]:
+def _validate_v1_3_0_format(data: dict[str, Any]) -> dict[str, Any]:
     """Validate and fill missing fields in v1.3.0 format
 
     Args:

--- a/shared/server_connection.py
+++ b/shared/server_connection.py
@@ -12,12 +12,18 @@ Effective path priority (highest first):
 import os
 import threading
 from pathlib import Path
-from typing import Optional
 
 from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton,
-    QFileDialog, QDialogButtonBox, QMessageBox,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
 )
 
 _SETTINGS_KEY = "server_path"
@@ -52,7 +58,7 @@ def test_path_reachable(path: str, timeout: int = 5) -> bool:
     return result.get("ok", False)
 
 
-def get_saved_server_path(org: str) -> Optional[str]:
+def get_saved_server_path(org: str) -> str | None:
     """Path saved via the UI for `org`, or None if never set."""
     value = QSettings(org, "Connection").value(_SETTINGS_KEY, None)
     return value or None

--- a/shared/session_id.py
+++ b/shared/session_id.py
@@ -3,10 +3,9 @@ Tool, so a record written by one and a record written by the other for the
 same real-world session carry the exact same session_id string.
 """
 from pathlib import Path
-from typing import Union
 
 
-def derive_session_id(session_path: Union[str, Path]) -> str:
+def derive_session_id(session_path: str | Path) -> str:
     """Derive a session_id from a session directory path.
 
     Both apps must call this instead of building their own session_id.

--- a/shared/stats_manager.py
+++ b/shared/stats_manager.py
@@ -42,15 +42,14 @@ import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any, Optional, List
+from typing import Any
 
-from shared.file_lock import locked_file, FileLockError
+from shared.file_lock import FileLockError, locked_file
 from shared.metadata_utils import get_current_timestamp, parse_timestamp
 
 
 class StatsManagerError(Exception):
     """Base exception for StatsManager errors."""
-    pass
 
 
 class StatsManager:
@@ -110,7 +109,7 @@ class StatsManager:
 
         self.stats_file.parent.mkdir(parents=True, exist_ok=True)
 
-    def _get_default_stats(self) -> Dict[str, Any]:
+    def _get_default_stats(self) -> dict[str, Any]:
         """Get default statistics structure."""
         return {
             "total_orders_analyzed": 0,
@@ -125,7 +124,7 @@ class StatsManager:
             "version": "2.0",
         }
 
-    def _load_stats(self) -> Dict[str, Any]:
+    def _load_stats(self) -> dict[str, Any]:
         """Load statistics from file with file locking."""
         if not self.stats_file.exists():
             return self._get_default_stats()
@@ -133,35 +132,34 @@ class StatsManager:
         for attempt in range(self.max_retries):
             try:
                 mode = 'r+' if self.stats_file.exists() else 'w+'
-                with open(self.stats_file, mode, encoding='utf-8') as f:
-                    with locked_file(f):
-                        f.seek(0)
-                        content = f.read()
-                        if not content.strip():
-                            return self._get_default_stats()
+                with open(self.stats_file, mode, encoding='utf-8') as f, locked_file(f):
+                    f.seek(0)
+                    content = f.read()
+                    if not content.strip():
+                        return self._get_default_stats()
 
-                        stats = json.loads(content)
+                    stats = json.loads(content)
 
-                        if not isinstance(stats, dict):
-                            return self._get_default_stats()
+                    if not isinstance(stats, dict):
+                        return self._get_default_stats()
 
-                        default = self._get_default_stats()
-                        for key in default:
-                            if key not in stats:
-                                stats[key] = default[key]
+                    default = self._get_default_stats()
+                    for key in default:
+                        if key not in stats:
+                            stats[key] = default[key]
 
-                        return stats
+                    return stats
 
             except json.JSONDecodeError:
                 return self._get_default_stats()
-            except (IOError, FileLockError) as e:
+            except (OSError, FileLockError) as e:
                 if attempt == self.max_retries - 1:
                     raise StatsManagerError(f"Failed to load stats after {self.max_retries} attempts: {e}")
                 time.sleep(self.retry_delay * (attempt + 1))
 
         return self._get_default_stats()
 
-    def _save_stats(self, stats: Dict[str, Any]) -> None:
+    def _save_stats(self, stats: dict[str, Any]) -> None:
         """Save statistics to file with file locking."""
         stats["last_updated"] = get_current_timestamp()
 
@@ -170,17 +168,16 @@ class StatsManager:
                 self.stats_file.parent.mkdir(parents=True, exist_ok=True)
 
                 mode = 'r+' if self.stats_file.exists() else 'w+'
-                with open(self.stats_file, mode, encoding='utf-8') as f:
-                    with locked_file(f):
-                        f.seek(0)
-                        f.truncate()
-                        json.dump(stats, f, indent=4, ensure_ascii=False)
-                        f.flush()
-                        os.fsync(f.fileno())
+                with open(self.stats_file, mode, encoding='utf-8') as f, locked_file(f):
+                    f.seek(0)
+                    f.truncate()
+                    json.dump(stats, f, indent=4, ensure_ascii=False)
+                    f.flush()
+                    os.fsync(f.fileno())
 
                 return
 
-            except (IOError, FileLockError) as e:
+            except (OSError, FileLockError) as e:
                 if attempt == self.max_retries - 1:
                     raise StatsManagerError(f"Failed to save stats after {self.max_retries} attempts: {e}")
                 time.sleep(self.retry_delay * (attempt + 1))
@@ -207,54 +204,53 @@ class StatsManager:
                     with open(self.stats_file, 'w', encoding='utf-8') as f:
                         json.dump(self._get_default_stats(), f, indent=4)
 
-                with open(self.stats_file, 'r+', encoding='utf-8') as f:
-                    with locked_file(f):
-                        f.seek(0)
-                        content = f.read()
-                        if content.strip():
-                            try:
-                                stats = json.loads(content)
-                            except json.JSONDecodeError:
-                                stats = self._get_default_stats()
-                        else:
-                            stats = self._get_default_stats()
-
-                        if not isinstance(stats, dict):
-                            stats = self._get_default_stats()
-
-                        default = self._get_default_stats()
-                        for key in default:
-                            if key not in stats:
-                                stats[key] = default[key]
-
-                        update_func(stats)
-
-                        stats["last_updated"] = get_current_timestamp()
-
-                        tmp_fd, tmp_name = tempfile.mkstemp(
-                            dir=self.stats_file.parent,
-                            prefix=f".{self.stats_file.stem}_tmp_",
-                            suffix=self.stats_file.suffix,
-                        )
+                with open(self.stats_file, 'r+', encoding='utf-8') as f, locked_file(f):
+                    f.seek(0)
+                    content = f.read()
+                    if content.strip():
                         try:
-                            with os.fdopen(tmp_fd, 'w', encoding='utf-8') as tmp_f:
-                                json.dump(stats, tmp_f, indent=4, ensure_ascii=False)
-                            new_content = Path(tmp_name).read_text(encoding='utf-8')
-                        finally:
-                            try:
-                                os.unlink(tmp_name)
-                            except OSError:
-                                pass
+                            stats = json.loads(content)
+                        except json.JSONDecodeError:
+                            stats = self._get_default_stats()
+                    else:
+                        stats = self._get_default_stats()
 
-                        f.seek(0)
-                        f.truncate()
-                        f.write(new_content)
-                        f.flush()
-                        os.fsync(f.fileno())
+                    if not isinstance(stats, dict):
+                        stats = self._get_default_stats()
+
+                    default = self._get_default_stats()
+                    for key in default:
+                        if key not in stats:
+                            stats[key] = default[key]
+
+                    update_func(stats)
+
+                    stats["last_updated"] = get_current_timestamp()
+
+                    tmp_fd, tmp_name = tempfile.mkstemp(
+                        dir=self.stats_file.parent,
+                        prefix=f".{self.stats_file.stem}_tmp_",
+                        suffix=self.stats_file.suffix,
+                    )
+                    try:
+                        with os.fdopen(tmp_fd, 'w', encoding='utf-8') as tmp_f:
+                            json.dump(stats, tmp_f, indent=4, ensure_ascii=False)
+                        new_content = Path(tmp_name).read_text(encoding='utf-8')
+                    finally:
+                        try:
+                            os.unlink(tmp_name)
+                        except OSError:
+                            pass
+
+                    f.seek(0)
+                    f.truncate()
+                    f.write(new_content)
+                    f.flush()
+                    os.fsync(f.fileno())
 
                 return  # Success
 
-            except (IOError, FileLockError) as e:
+            except (OSError, FileLockError) as e:
                 if attempt == self.max_retries - 1:
                     raise StatsManagerError(f"Failed to update stats after {self.max_retries} attempts: {e}")
                 time.sleep(self.retry_delay * (attempt + 1))
@@ -264,7 +260,7 @@ class StatsManager:
         client_id: str,
         session_id: str,
         orders_count: int,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: dict[str, Any] | None = None
     ) -> None:
         """Record an analysis completion from Shopify Tool.
 
@@ -309,10 +305,10 @@ class StatsManager:
         self,
         client_id: str,
         session_id: str,
-        worker_id: Optional[str],
+        worker_id: str | None,
         orders_count: int,
         items_count: int,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: dict[str, Any] | None = None
     ) -> None:
         """Record a packing session completion from Packing Tool.
 
@@ -358,7 +354,7 @@ class StatsManager:
 
         self._atomic_update(update)
 
-    def get_global_stats(self) -> Dict[str, Any]:
+    def get_global_stats(self) -> dict[str, Any]:
         """Get global statistics summary."""
         stats = self._load_stats()
         return {
@@ -368,23 +364,23 @@ class StatsManager:
             "last_updated": stats.get("last_updated"),
         }
 
-    def get_client_stats(self, client_id: str) -> Dict[str, Any]:
+    def get_client_stats(self, client_id: str) -> dict[str, Any]:
         """Get statistics for a specific client."""
         stats = self._load_stats()
         if client_id not in stats.get("by_client", {}):
             return {"orders_analyzed": 0, "orders_packed": 0, "sessions": 0}
         return stats["by_client"][client_id].copy()
 
-    def get_all_clients_stats(self) -> Dict[str, Dict[str, Any]]:
+    def get_all_clients_stats(self) -> dict[str, dict[str, Any]]:
         """Get statistics for all clients."""
         stats = self._load_stats()
         return stats.get("by_client", {}).copy()
 
     def get_analysis_history(
         self,
-        client_id: Optional[str] = None,
-        limit: Optional[int] = None
-    ) -> List[Dict[str, Any]]:
+        client_id: str | None = None,
+        limit: int | None = None
+    ) -> list[dict[str, Any]]:
         """Get analysis history with optional filtering (newest first)."""
         stats = self._load_stats()
         history = stats.get("analysis_history", [])
@@ -401,10 +397,10 @@ class StatsManager:
 
     def get_packing_history(
         self,
-        client_id: Optional[str] = None,
-        worker_id: Optional[str] = None,
-        limit: Optional[int] = None
-    ) -> List[Dict[str, Any]]:
+        client_id: str | None = None,
+        worker_id: str | None = None,
+        limit: int | None = None
+    ) -> list[dict[str, Any]]:
         """Get packing history with optional filtering (newest first)."""
         stats = self._load_stats()
         history = stats.get("packing_history", [])
@@ -459,11 +455,11 @@ class StatsManager:
 
     def get_label_print_history(
         self,
-        client_id: Optional[str] = None,
-        start_date: Optional[datetime] = None,
-        end_date: Optional[datetime] = None,
-        limit: Optional[int] = None,
-    ) -> List[Dict[str, Any]]:
+        client_id: str | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
         """Get label print history with optional filtering.
 
         start_date/end_date may be naive or timezone-aware (the GUI builds
@@ -509,12 +505,12 @@ class StatsManager:
 
     def get_label_stats(
         self,
-        client_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        client_id: str | None = None,
+    ) -> dict[str, Any]:
         """Get label printing summary statistics."""
         history = self.get_label_print_history(client_id=client_id)
 
-        sku_counts: Dict[str, int] = {}
+        sku_counts: dict[str, int] = {}
         for record in history:
             sku = record.get("sku", "Unknown")
             sku_counts[sku] = sku_counts.get(sku, 0) + record.get("copies", 1)

--- a/shared/theme.py
+++ b/shared/theme.py
@@ -376,7 +376,7 @@ def build_stylesheet(theme: ThemeTokens) -> str:
 def build_palette(theme: ThemeTokens):
     """Build a QPalette for one theme. Import is local so this module stays
     importable in a pure-Python (no Qt) context, e.g. under plain pytest."""
-    from PySide6.QtGui import QPalette, QColor
+    from PySide6.QtGui import QColor, QPalette
 
     palette = QPalette()
     palette.setColor(QPalette.ColorRole.Window, QColor(theme.background))

--- a/src/async_state_writer.py
+++ b/src/async_state_writer.py
@@ -6,10 +6,10 @@ The latest state is always kept in a single pending slot — never accumulates s
 """
 
 import copy
-import threading
-from typing import Callable, Dict, Any, Optional
-
 import logging
+import threading
+from collections.abc import Callable
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ class AsyncStateWriter:
 
     def __init__(
         self,
-        write_fn: Callable[[Dict[str, Any]], None],
+        write_fn: Callable[[dict[str, Any]], None],
         sync_mode: bool = False,
     ) -> None:
         self._write_fn = write_fn
@@ -45,7 +45,7 @@ class AsyncStateWriter:
             return  # No thread needed
 
         self._condition = threading.Condition()
-        self._pending: Optional[Dict[str, Any]] = None
+        self._pending: dict[str, Any] | None = None
         self._is_writing: bool = False  # True while write_fn is executing
         self._stop = False
         self._thread = threading.Thread(
@@ -57,7 +57,7 @@ class AsyncStateWriter:
     # Public API
     # ------------------------------------------------------------------
 
-    def schedule(self, state_dict: Dict[str, Any]) -> None:
+    def schedule(self, state_dict: dict[str, Any]) -> None:
         """
         Non-blocking: schedule state_dict for writing.
 

--- a/src/custom_filter_proxy_model.py
+++ b/src/custom_filter_proxy_model.py
@@ -1,6 +1,7 @@
-from PySide6.QtCore import QSortFilterProxyModel, Qt, QModelIndex
-from PySide6.QtWidgets import QWidget
 import pandas as pd
+from PySide6.QtCore import QModelIndex, QSortFilterProxyModel, Qt
+from PySide6.QtWidgets import QWidget
+
 
 class CustomFilterProxyModel(QSortFilterProxyModel):
     """

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -39,6 +39,13 @@ class PackingToolError(Exception):
     """
 
 
+class SessionAlreadyActiveError(PackingToolError):
+    """
+    Raised when starting a session while this SessionManager instance already
+    has one active. Callers must end_session() first.
+    """
+
+
 class SessionLockedError(PackingToolError):
     """
     Raised when attempting to access a session actively locked by another process.

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -20,7 +20,6 @@ Exception hierarchy:
         └── StaleLockError (crashed session, can be force-released)
 """
 
-from typing import Dict, Optional
 
 
 class PackingToolError(Exception):
@@ -63,7 +62,7 @@ class SessionLockedError(PackingToolError):
         lock_info (Dict): Dictionary containing lock details from .session.lock file
     """
 
-    def __init__(self, message: str, lock_info: Optional[Dict] = None):
+    def __init__(self, message: str, lock_info: dict | None = None):
         """
         Initialize SessionLockedError with lock details.
 
@@ -159,7 +158,7 @@ class StaleLockError(SessionLockedError):
         stale_minutes (int): Minutes since last heartbeat update
     """
 
-    def __init__(self, message: str, lock_info: Optional[Dict] = None, stale_minutes: int = 0):
+    def __init__(self, message: str, lock_info: dict | None = None, stale_minutes: int = 0):
         """
         Initialize StaleLockError with staleness information.
 

--- a/src/json_cache.py
+++ b/src/json_cache.py
@@ -31,11 +31,11 @@ Version: 1.0.0
 
 import copy
 import json
-import time
-import threading
-from pathlib import Path
-from typing import Dict, Any, Optional
 import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -90,14 +90,14 @@ class JSONCache:
         """
         self.max_size = max_size
         self.ttl_seconds = ttl_seconds
-        self._cache: Dict[str, Dict[str, Any]] = {}
-        self._access_times: Dict[str, float] = {}
-        self._insert_times: Dict[str, float] = {}
+        self._cache: dict[str, dict[str, Any]] = {}
+        self._access_times: dict[str, float] = {}
+        self._insert_times: dict[str, float] = {}
         self._lock = threading.RLock()
 
         logger.debug(f"JSONCache initialized: max_size={max_size}, ttl={ttl_seconds}s")
 
-    def get(self, file_path: Path, default: Optional[Any] = None) -> Any:
+    def get(self, file_path: Path, default: Any | None = None) -> Any:
         """
         Get JSON data from file with caching.
 
@@ -162,8 +162,8 @@ class JSONCache:
         except json.JSONDecodeError as e:
             logger.warning(f"Invalid JSON in {file_path}: {e}")
             return default
-        except Exception as e:
-            logger.error(f"Error reading {file_path}: {e}", exc_info=True)
+        except Exception:
+            logger.exception(f"Error reading {file_path}")
             return default
 
         # Re-acquire lock to insert; another thread may have beat us here —
@@ -253,7 +253,7 @@ _json_cache = JSONCache(max_size=100, ttl_seconds=60)
 # Simple wrapper functions for common cache operations
 # These provide a clean API for the rest of the application
 
-def get_cached_json(file_path: Path, default: Optional[Any] = None) -> Any:
+def get_cached_json(file_path: Path, default: Any | None = None) -> Any:
     """
     Convenience function to get JSON from global cache.
 

--- a/src/main.py
+++ b/src/main.py
@@ -1621,6 +1621,12 @@ class MainWindow(QMainWindow):
                     if _session_info and 'started_at' in _session_info:
                         try:
                             _start_time = datetime.fromisoformat(_session_info['started_at'])
+                            if _start_time.tzinfo is None:
+                                # Legacy session_info.json from before timestamps were
+                                # made timezone-aware; interpret as local time so the
+                                # subtraction against tz-aware _end_time below doesn't
+                                # raise TypeError.
+                                _start_time = _start_time.astimezone()
                         except (ValueError, TypeError):
                             logger.warning("Could not parse started_at from session_info")
                 except Exception as e:
@@ -1699,6 +1705,7 @@ class MainWindow(QMainWindow):
                     except Exception as exc:
                         logger.exception("save_session_summary failed")
                         try:
+                            from shared.atomic_write import atomic_write_json
                             from shared.metadata_utils import get_current_timestamp
                             _minimal = {
                                 "version": "1.3.0",
@@ -1710,8 +1717,7 @@ class MainWindow(QMainWindow):
                                 "completed_at": get_current_timestamp(),
                                 "error": str(exc),
                             }
-                            with open(_summary_path, 'w', encoding='utf-8') as _f:
-                                json.dump(_minimal, _f, indent=2, ensure_ascii=False)
+                            atomic_write_json(_summary_path, _minimal, indent=2, ensure_ascii=False)
                         except Exception as minimal_exc:
                             logger.debug(f"Failed to write minimal session summary fallback: {minimal_exc}")
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,9 @@
-import sys
-import os
 import json
+import os
+import sys
 import threading
 from pathlib import Path
+from typing import ClassVar
 
 try:
     import winsound as _winsound
@@ -20,36 +21,54 @@ except ImportError:
 project_root = Path(__file__).parent.parent
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
-from PySide6.QtWidgets import (
-    QApplication, QMainWindow, QLabel, QPushButton, QVBoxLayout, QWidget, QFileDialog, QStackedWidget,
-    QHBoxLayout, QMessageBox, QLineEdit, QComboBox, QDialog, QFormLayout, QDialogButtonBox, QTabWidget,
-    QTreeWidget, QTreeWidgetItem, QTableWidget, QTableWidgetItem, QGroupBox, QScrollArea, QInputDialog,
-    QProgressDialog
-)
-from PySide6.QtGui import QAction, QFont, QCloseEvent, QKeySequence
-from PySide6.QtCore import QTimer, QSettings, QSize, Qt, QThread, Signal
-from datetime import datetime
-from openpyxl.styles import PatternFill
-import pandas as pd
-
 import logging
-from profile_manager import ProfileManager, NetworkError, ValidationError
-from session_lock_manager import SessionLockManager
+from datetime import datetime
+
+import pandas as pd
+from openpyxl.styles import PatternFill
+from PySide6.QtCore import QSettings, QSize, Qt, QThread, QTimer
+from PySide6.QtGui import QAction, QCloseEvent, QFont, QKeySequence
+from PySide6.QtWidgets import (
+    QApplication,
+    QComboBox,
+    QDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QMainWindow,
+    QMessageBox,
+    QProgressDialog,
+    QPushButton,
+    QScrollArea,
+    QStackedWidget,
+    QTableWidget,
+    QTableWidgetItem,
+    QTabWidget,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
 from exceptions import SessionLockedError, StaleLockError
-from session_selector import SessionSelectorDialog
+from packer_logic import PackerLogic
 from packer_mode_widget import PackerModeWidget
-from packer_logic import PackerLogic, REQUIRED_COLUMNS
-from session_manager import SessionManager
-from shared.stats_manager import StatsManager
-from shared.session_id import derive_session_id
-from shared.server_connection import ConnectionSettingsDialog, prompt_for_recovery_path
-from worker_manager import WorkerManager
-from sku_mapping_dialog import SKUMappingDialog
-from session_history_manager import SessionHistoryManager
+from profile_manager import NetworkError, ProfileManager
 from session_browser.session_browser_widget import SessionBrowserWidget
+from session_history_manager import SessionHistoryManager
+from session_lock_manager import SessionLockManager
+from session_manager import SessionManager
 from session_registry_manager import SessionRegistryManager
-from worker_selection_dialog import WorkerSelectionDialog
+from session_selector import SessionSelectorDialog
+from shared.server_connection import ConnectionSettingsDialog, prompt_for_recovery_path
+from shared.session_id import derive_session_id
+from shared.stats_manager import StatsManager
+from sku_mapping_dialog import SKUMappingDialog
 from theme import load_saved_theme, toggle_theme
+from worker_manager import WorkerManager
+from worker_selection_dialog import WorkerSelectionDialog
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +151,7 @@ class SessionEndWorker(QThread):
         try:
             self._write_fn()
         except Exception as exc:
-            logger.error(f"SessionEndWorker: unexpected error: {exc}", exc_info=True)
+            logger.exception("SessionEndWorker: unexpected error")
             self.error = exc
 
 
@@ -184,12 +203,12 @@ class MainWindow(QMainWindow):
                 logger.info("ProfileManager initialized successfully")
                 break
             except NetworkError as e:
-                logger.error(f"Failed to initialize ProfileManager: {e}", exc_info=True)
+                logger.exception("Failed to initialize ProfileManager")
                 if prompt_for_recovery_path(self, str(e), "PackingTool"):
                     continue
                 sys.exit(1)
             except Exception as e:
-                logger.error(f"Unexpected error initializing ProfileManager: {e}", exc_info=True)
+                logger.exception("Unexpected error initializing ProfileManager")
                 QMessageBox.critical(self, "Error", f"Failed to initialize application:\n\n{e}")
             sys.exit(1)
 
@@ -590,12 +609,12 @@ class MainWindow(QMainWindow):
                 elif is_completed:
                     try:
                         scanned_qty = int(qty)
-                    except:
+                    except (ValueError, TypeError):
                         scanned_qty = 1
 
                 try:
                     qty_int = int(qty)
-                except:
+                except (ValueError, TypeError):
                     qty_int = 1
 
                 if scanned_qty >= qty_int:
@@ -753,7 +772,7 @@ class MainWindow(QMainWindow):
         completed_orders = len(completed_orders_list)
         total_items = len(df)
         unique_skus = df['SKU'].nunique()
-        progress_pct = int((completed_orders / total_orders * 100)) if total_orders > 0 else 0
+        progress_pct = int(completed_orders / total_orders * 100) if total_orders > 0 else 0
 
         self.stats_total_orders.setText(str(total_orders))
         self.stats_completed_orders.setText(str(completed_orders))
@@ -892,11 +911,11 @@ class MainWindow(QMainWindow):
             return False
 
         except Exception as e:
-            logger.error(f"Worker selection failed: {e}", exc_info=True)
+            logger.exception("Worker selection failed")
             QMessageBox.critical(
                 self,
                 "Error",
-                f"Failed to load worker profiles:\n{str(e)}\n\nApplication will exit."
+                f"Failed to load worker profiles:\n{e!s}\n\nApplication will exit."
             )
             return False
 
@@ -944,7 +963,7 @@ class MainWindow(QMainWindow):
             logger.info(f"Loaded {len(clients)} clients")
 
         except Exception as e:
-            logger.error(f"Error loading clients: {e}", exc_info=True)
+            logger.exception("Error loading clients")
             QMessageBox.warning(self, "Error", f"Failed to load clients:\n\n{e}")
 
         finally:
@@ -983,7 +1002,7 @@ class MainWindow(QMainWindow):
         logger.debug(f"Current client set to: {client_id}")
 
     # Muted theme-aware flash colors
-    _FLASH_COLORS = {
+    _FLASH_COLORS: ClassVar[dict[str, str]] = {
         "green": "#43a047",
         "red": "#c0392b",
         "orange": "#b06020",
@@ -1009,7 +1028,7 @@ class MainWindow(QMainWindow):
         )
 
 
-    def start_session(self, file_path: str = None, restore_dir: str = None):
+    def start_session(self, file_path: str | None = None, restore_dir: str | None = None):
         """
         Start a new packing session for the currently selected client.
 
@@ -1116,7 +1135,7 @@ class MainWindow(QMainWindow):
             self.logic = None
 
         except Exception as e:
-            logger.error(f"Failed to start session: {e}", exc_info=True)
+            logger.exception("Failed to start session")
             QMessageBox.critical(self, "Error", f"Failed to start session:\n\n{e}")
             if self.session_manager:
                 self.session_manager.end_session()
@@ -1169,7 +1188,7 @@ class MainWindow(QMainWindow):
                     self.status_label.setText("SKU mapping updated and synchronized across all PCs.")
                     logger.info("SKU mapping reloaded into active session")
                 except Exception as e:
-                    logger.error(f"Failed to reload SKU mapping into session: {e}", exc_info=True)
+                    logger.exception("Failed to reload SKU mapping into session")
                     QMessageBox.warning(
                         self,
                         "Reload Warning",
@@ -1193,8 +1212,8 @@ class MainWindow(QMainWindow):
             try:
                 self.lock_manager.update_heartbeat(Path(self.current_work_dir))
                 logger.debug("Lock heartbeat updated")
-            except Exception as e:
-                logger.error(f"Failed to update heartbeat: {e}", exc_info=True)
+            except Exception:
+                logger.exception("Failed to update heartbeat")
 
     def _cleanup_failed_session_start(self):
         """
@@ -1304,9 +1323,9 @@ class MainWindow(QMainWindow):
 
             logger.info("Application cleanup completed successfully")
 
-        except Exception as e:
+        except Exception:
             # Log but don't prevent shutdown
-            logger.error(f"Error during application cleanup: {e}", exc_info=True)
+            logger.exception("Error during application cleanup")
 
         # Always accept the event (allow application to close)
         event.accept()
@@ -1465,52 +1484,52 @@ class MainWindow(QMainWindow):
             return True
 
         except FileNotFoundError as e:
-            logger.error(f"Packing list file not found: {e}", exc_info=True)
+            logger.exception("Packing list file not found")
             self._cleanup_failed_session_start()
             QMessageBox.critical(
                 self,
                 "File Not Found",
-                f"Packing list file not found:\n{str(e)}"
+                f"Packing list file not found:\n{e!s}"
             )
             return False
 
         except json.JSONDecodeError as e:
-            logger.error(f"Invalid JSON in packing list: {e}", exc_info=True)
+            logger.exception("Invalid JSON in packing list")
             self._cleanup_failed_session_start()
             QMessageBox.critical(
                 self,
                 "Invalid JSON",
-                f"Packing list contains invalid JSON:\n{str(e)}"
+                f"Packing list contains invalid JSON:\n{e!s}"
             )
             return False
 
         except ValueError as e:
-            logger.error(f"Invalid packing data: {e}", exc_info=True)
+            logger.exception("Invalid packing data")
             self._cleanup_failed_session_start()
             QMessageBox.critical(
                 self,
                 "Invalid Data",
-                f"Packing list contains invalid data:\n{str(e)}"
+                f"Packing list contains invalid data:\n{e!s}"
             )
             return False
 
         except RuntimeError as e:
-            logger.error(f"Failed to start session: {e}", exc_info=True)
+            logger.exception("Failed to start session")
             self._cleanup_failed_session_start()
             QMessageBox.critical(
                 self,
                 "Session Start Failed",
-                f"Failed to start packing session:\n{str(e)}"
+                f"Failed to start packing session:\n{e!s}"
             )
             return False
 
         except Exception as e:
-            logger.error(f"Unexpected error starting session: {e}", exc_info=True)
+            logger.exception("Unexpected error starting session")
             self._cleanup_failed_session_start()
             QMessageBox.critical(
                 self,
                 "Error",
-                f"Unexpected error starting packing session:\n{str(e)}"
+                f"Unexpected error starting packing session:\n{e!s}"
             )
             return False
 
@@ -1565,12 +1584,11 @@ class MainWindow(QMainWindow):
 
             # Add Completed At column
             final_df['Completed At'] = final_df['Order_Number'].apply(
-                lambda x: datetime.now().strftime("%Y-%m-%d %H:%M:%S") if x in completed_orders_set else ''
+                lambda x: datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S") if x in completed_orders_set else ''
             )
 
             with pd.ExcelWriter(output_path, engine='openpyxl') as writer:
                 final_df.to_excel(writer, index=False, sheet_name='Sheet1')
-                workbook = writer.book
                 worksheet = writer.sheets['Sheet1']
                 green_fill = PatternFill(start_color="C6EFCE", end_color="C6EFCE", fill_type="solid")
                 status_col_idx = final_df.columns.get_loc('Status') + 1
@@ -1610,7 +1628,7 @@ class MainWindow(QMainWindow):
                     _session_info = None
                     _start_time = None
 
-                _end_time = datetime.now()
+                _end_time = datetime.now().astimezone()
                 _completed_orders_list = self.logic.session_packing_state.get('completed_orders', [])
                 _completed_orders = len(_completed_orders_list)
                 _in_progress_orders_dict = self.logic.session_packing_state.get('in_progress', {})
@@ -1631,16 +1649,16 @@ class MainWindow(QMainWindow):
                             for _sd in _osl:
                                 if isinstance(_sd, dict):
                                     _items_packed += _sd.get('packed', 0)
-                except Exception as e:
-                    logger.error(f"Error calculating items_packed: {e}", exc_info=True)
+                except Exception:
+                    logger.exception("Error calculating items_packed")
 
                 _total_orders, _total_items = 0, 0
                 try:
                     if self.logic.processed_df is not None:
                         _total_orders = len(self.logic.processed_df['Order_Number'].unique())
                         _total_items = int(pd.to_numeric(self.logic.processed_df['Quantity'], errors='coerce').sum())
-                except Exception as e:
-                    logger.error(f"Error calculating totals: {e}", exc_info=True)
+                except Exception:
+                    logger.exception("Error calculating totals")
 
                 if _is_shopify:
                     _session_id = derive_session_id(getattr(self, 'current_session_path', ''))
@@ -1679,7 +1697,7 @@ class MainWindow(QMainWindow):
                         )
                         logger.info(f"Session summary saved to: {_summary_path}")
                     except Exception as exc:
-                        logger.error(f"save_session_summary failed: {exc}", exc_info=True)
+                        logger.exception("save_session_summary failed")
                         try:
                             from shared.metadata_utils import get_current_timestamp
                             _minimal = {
@@ -1694,8 +1712,8 @@ class MainWindow(QMainWindow):
                             }
                             with open(_summary_path, 'w', encoding='utf-8') as _f:
                                 json.dump(_minimal, _f, indent=2, ensure_ascii=False)
-                        except Exception:
-                            pass
+                        except Exception as minimal_exc:
+                            logger.debug(f"Failed to write minimal session summary fallback: {minimal_exc}")
 
                     # 2. Record to stats
                     try:
@@ -1719,8 +1737,8 @@ class MainWindow(QMainWindow):
                             },
                         )
                         logger.info(f"Recorded {_completed_orders} orders, {_items_packed} items to stats")
-                    except Exception as exc:
-                        logger.error(f"record_packing failed: {exc}", exc_info=True)
+                    except Exception:
+                        logger.exception("record_packing failed")
 
                     # 3. Update worker stats
                     try:
@@ -1734,8 +1752,8 @@ class MainWindow(QMainWindow):
                                 session_id=_session_id,
                             )
                             logger.info(f"Updated worker stats for {_worker_name}")
-                    except Exception as exc:
-                        logger.error(f"update_worker_stats failed: {exc}", exc_info=True)
+                    except Exception:
+                        logger.exception("update_worker_stats failed")
 
                     # 4. Update session metadata
                     try:
@@ -1784,7 +1802,7 @@ class MainWindow(QMainWindow):
 
         except Exception as e:
             self.status_label.setText(f"Could not save the report. Error: {e}")
-            logger.error(f"Error during end_session: {e}", exc_info=True)
+            logger.exception("Error during end_session")
 
         # CRITICAL: Stop heartbeat timer and release lock
         if hasattr(self, 'heartbeat_timer'):
@@ -1795,8 +1813,8 @@ class MainWindow(QMainWindow):
             try:
                 self.lock_manager.release_lock(Path(self.current_work_dir))
                 logger.info("Lock released")
-            except Exception as e:
-                logger.error(f"Failed to release lock: {e}", exc_info=True)
+            except Exception:
+                logger.exception("Failed to release lock")
 
         # Cleanup PackerLogic state
         if self.logic:
@@ -2074,7 +2092,7 @@ class MainWindow(QMainWindow):
             else:
                 QMessageBox.warning(self, "Save Failed", "Could not save mapping to file server.")
         except Exception as e:
-            logger.error(f"Failed to save quick SKU mapping: {e}", exc_info=True)
+            logger.exception("Failed to save quick SKU mapping")
             QMessageBox.critical(self, "Error", f"Failed to save mapping:\n\n{e}")
 
         self.packer_mode_widget.set_focus_to_scanner()
@@ -2256,7 +2274,6 @@ class MainWindow(QMainWindow):
 
                 # Get order count for success message
                 order_count = self.packing_data.get('total_orders', 0)
-                list_name = self.packing_data.get('list_name', packing_list_name)
 
                 QMessageBox.information(
                     self,
@@ -2353,25 +2370,25 @@ class MainWindow(QMainWindow):
         except Exception as e:
             # Only handle exceptions from full_session mode
             # (packing_list mode errors are handled by unified method)
-            logger.error(f"Failed to load session: {e}", exc_info=True)
+            logger.exception("Failed to load session")
             self._cleanup_failed_session_start()
 
             # Determine error message based on exception type
             if isinstance(e, FileNotFoundError):
                 title = "File Not Found"
-                message = f"Session file not found:\n{str(e)}"
+                message = f"Session file not found:\n{e!s}"
             elif isinstance(e, json.JSONDecodeError):
                 title = "Invalid JSON"
-                message = f"Session contains invalid JSON:\n{str(e)}"
+                message = f"Session contains invalid JSON:\n{e!s}"
             elif isinstance(e, (KeyError, ValueError)):
                 title = "Invalid Data"
-                message = f"Session data validation failed:\n{str(e)}"
+                message = f"Session data validation failed:\n{e!s}"
             elif isinstance(e, RuntimeError):
                 title = "Session Load Failed"
-                message = f"Failed to load session:\n{str(e)}"
+                message = f"Failed to load session:\n{e!s}"
             else:
                 title = "Error"
-                message = f"Unexpected error loading session:\n{str(e)}"
+                message = f"Unexpected error loading session:\n{e!s}"
 
             QMessageBox.critical(self, title, message)
 
@@ -2632,7 +2649,7 @@ class MainWindow(QMainWindow):
             from datetime import datetime
             lock_dt = datetime.fromisoformat(lock_time)
             lock_time_formatted = lock_dt.strftime('%d.%m.%Y %H:%M')
-        except:
+        except (ValueError, TypeError):
             lock_time_formatted = lock_time
 
         msg = QMessageBox(self)
@@ -2674,7 +2691,7 @@ class MainWindow(QMainWindow):
             from datetime import datetime
             heartbeat_dt = datetime.fromisoformat(heartbeat)
             heartbeat_formatted = heartbeat_dt.strftime('%d.%m.%Y %H:%M')
-        except:
+        except (ValueError, TypeError):
             heartbeat_formatted = heartbeat
 
         msg = QMessageBox(self)
@@ -2711,7 +2728,7 @@ class MainWindow(QMainWindow):
                         "Failed to release the lock. Please try again or contact support."
                     )
             except Exception as e:
-                logger.error(f"Error force-releasing lock: {e}", exc_info=True)
+                logger.exception("Error force-releasing lock")
                 QMessageBox.critical(
                     self,
                     "Error",

--- a/src/order_table_model.py
+++ b/src/order_table_model.py
@@ -1,8 +1,10 @@
-from PySide6.QtCore import QAbstractTableModel, Qt, QModelIndex
+from typing import Any
+
+import pandas as pd
+from PySide6.QtCore import QAbstractTableModel, QModelIndex, Qt
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QWidget
-import pandas as pd
-from typing import Any
+
 
 class OrderTableModel(QAbstractTableModel):
     """

--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -1,24 +1,24 @@
 # Standard library imports
+# Data persistence and utilities
+import json
+
+# Local imports
+import logging
 import os
+from datetime import datetime
+from pathlib import Path
+
+# Type hints for better code documentation
+from typing import Any
 
 # Third-party imports for data processing
 import pandas as pd  # Excel file handling and data manipulation
 
-# Data persistence and utilities
-import json
-from pathlib import Path
-from datetime import datetime
-
 # Qt framework for signals/slots pattern
 from PySide6.QtCore import QObject, Signal
 
-# Type hints for better code documentation
-from typing import List, Dict, Any, Tuple
-
-# Local imports
-import logging
-from json_cache import get_cached_json, invalidate_json_cache
 from async_state_writer import AsyncStateWriter
+from json_cache import get_cached_json, invalidate_json_cache
 from shared.atomic_write import atomic_write_json
 
 # Initialize module-level logger
@@ -76,7 +76,7 @@ STATE_FILE_NAME = "packing_state.json"
 SUMMARY_FILE_NAME = "session_summary.json"
 
 
-def compute_order_timing_metrics(orders_with_timing: List[Dict]) -> Dict[str, Any]:
+def compute_order_timing_metrics(orders_with_timing: list[dict]) -> dict[str, Any]:
     """
     Compute per-order timing metrics from a list of completed-order dicts.
 
@@ -197,7 +197,7 @@ class PackerLogic(QObject):
         self.packing_list_df = None
         self.processed_df = None
         self.orders_data = {}
-        self._normalized_order_lookup: Dict[str, str] = {}
+        self._normalized_order_lookup: dict[str, str] = {}
         self._total_items: int = 0
         self.current_order_number = None
         self.current_order_state = {}
@@ -226,7 +226,7 @@ class PackerLogic(QObject):
         # Extra items tracking: normalized_sku → extra count (scanned beyond required).
         # Also initialized BEFORE _load_session_state() so crash-recovered extras
         # (from '_current_extras') survive a restart instead of being wiped.
-        self.current_extra_items: Dict[str, int] = {}
+        self.current_extra_items: dict[str, int] = {}
 
         # Per-order counters for 1.7 metrics — reset by start_order_packing()
         self.current_order_corrections: int = 0           # cancel_item_scan() events
@@ -240,7 +240,7 @@ class PackerLogic(QObject):
         self._load_session_state()
 
         # Unknown/incorrect scan tracking: raw barcodes that didn't match any SKU
-        self.unknown_scans: List[str] = []
+        self.unknown_scans: list[str] = []
 
         # Write-behind queue: state writes happen in background to avoid UI freezes.
         # sync_mode=True is used in tests to keep writes synchronous.
@@ -253,7 +253,7 @@ class PackerLogic(QObject):
         logger.debug(f"Loaded {len(self.sku_map)} SKU mappings")
         logger.debug("Phase 2b timing variables initialized (loaded from state if available)")
 
-    def _load_sku_mapping(self) -> Dict[str, str]:
+    def _load_sku_mapping(self) -> dict[str, str]:
         """
         Load SKU mapping from ProfileManager for the current client.
 
@@ -286,13 +286,13 @@ class PackerLogic(QObject):
 
             logger.debug(f"Loaded {len(normalized)} SKU mappings for client {self.client_id}")
             return normalized
-        except Exception as e:
+        except Exception:
             # Graceful degradation: if SKU mapping fails to load, continue without it
             # Scanned barcodes will be matched directly against order SKUs
-            logger.error(f"Error loading SKU mappings: {e}", exc_info=True)
+            logger.exception("Error loading SKU mappings")
             return {}
 
-    def set_sku_map(self, sku_map: Dict[str, str]):
+    def set_sku_map(self, sku_map: dict[str, str]):
         """
         Set the SKU map and save to ProfileManager.
 
@@ -315,8 +315,8 @@ class PackerLogic(QObject):
         try:
             self.profile_manager.save_sku_mapping(self.client_id, sku_map)
             logger.info("SKU mapping saved successfully")
-        except Exception as e:
-            logger.error(f"Failed to save SKU mapping: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to save SKU mapping")
 
     def _get_state_file_path(self) -> str:
         """
@@ -533,11 +533,11 @@ class PackerLogic(QObject):
 
             logger.info(f"Session state loaded: {in_progress_count} in progress, {completed_count} completed")
 
-        except (json.JSONDecodeError, IOError) as e:
-            logger.error(f"Error loading session state: {e}, starting fresh", exc_info=True)
+        except (OSError, json.JSONDecodeError):
+            logger.exception("Error loading session state, starting fresh")
             self.session_packing_state = {'in_progress': {}, 'completed_orders': [], 'skipped_orders': [], 'skipped_orders_timing': {}}
 
-    def _build_state_dict(self) -> Dict[str, Any]:
+    def _build_state_dict(self) -> dict[str, Any]:
         """
         Build the complete state dictionary from current in-memory data.
 
@@ -597,7 +597,7 @@ class PackerLogic(QObject):
             "skipped_orders_timing": dict(self.session_packing_state.get('skipped_orders_timing', {})),
         }
 
-    def _do_atomic_write(self, state_data: Dict[str, Any]) -> None:
+    def _do_atomic_write(self, state_data: dict[str, Any]) -> None:
         """
         Write state_data to disk using the shared atomic (temp-file + rename)
         helper, with the same retry-on-transient-SMB-error behavior as every
@@ -618,8 +618,8 @@ class PackerLogic(QObject):
 
             logger.debug(f"Session state saved: {completed_orders_count}/{total_orders} orders, {packed_items}/{total_items} items")
 
-        except Exception as e:
-            logger.error(f"CRITICAL: Failed to save session state: {e}", exc_info=True)
+        except Exception:
+            logger.exception("CRITICAL: Failed to save session state")
 
     def _save_session_state_async(self) -> None:
         """
@@ -653,7 +653,7 @@ class PackerLogic(QObject):
         """
         self._state_writer.shutdown()
 
-    def _build_completed_list(self) -> List[Dict[str, Any]]:
+    def _build_completed_list(self) -> list[dict[str, Any]]:
         """
         Build list of completed orders with timestamps and durations.
 
@@ -698,7 +698,7 @@ class PackerLogic(QObject):
 
         Phase 2b: Enhanced timing tracking
         """
-        from shared.metadata_utils import get_current_timestamp, calculate_duration
+        from shared.metadata_utils import calculate_duration, get_current_timestamp
 
         if not self.current_order_number:
             logger.warning("_complete_current_order called but no current order")
@@ -760,7 +760,7 @@ class PackerLogic(QObject):
         # for legacy state management. The reset happens in clear_current_order() or
         # when starting a new order.
 
-    def _initialize_session_metadata(self, session_id: str = None, packing_list_name: str = None):
+    def _initialize_session_metadata(self, session_id: str | None = None, packing_list_name: str | None = None):
         """
         Initialize session metadata for state tracking.
 
@@ -780,7 +780,7 @@ class PackerLogic(QObject):
             self.session_id = session_id
         elif not self.session_id:
             # Generate session_id from timestamp if not provided
-            self.session_id = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            self.session_id = datetime.now().astimezone().strftime("%Y-%m-%d_%H-%M-%S")
 
         if packing_list_name:
             self.packing_list_name = packing_list_name
@@ -840,7 +840,7 @@ class PackerLogic(QObject):
             for order_number in self.orders_data
         }
 
-    def start_order_packing(self, scanned_text: str) -> Tuple[List[Dict] | None, str]:
+    def start_order_packing(self, scanned_text: str) -> tuple[list[dict] | None, str]:
         """
         Starts or resumes packing an order based on a scanned barcode.
 
@@ -938,7 +938,7 @@ class PackerLogic(QObject):
 
         return items, "ORDER_LOADED"
 
-    def process_sku_scan(self, sku: str) -> Tuple[Dict | None, str]:
+    def process_sku_scan(self, sku: str) -> tuple[dict | None, str]:
         """
         Processes a scanned SKU for the currently active order.
 
@@ -1031,7 +1031,7 @@ class PackerLogic(QObject):
             is_complete = found_item['packed'] == found_item['required']
 
             # Phase 2b: Record item scan with timestamp
-            from shared.metadata_utils import get_current_timestamp, calculate_duration
+            from shared.metadata_utils import calculate_duration, get_current_timestamp
 
             scan_timestamp = get_current_timestamp()
 
@@ -1191,7 +1191,7 @@ class PackerLogic(QObject):
         if self.current_order_number in skipped:
             skipped.remove(self.current_order_number)
 
-    def cancel_item_scan(self, row: int) -> Tuple[Dict, str]:
+    def cancel_item_scan(self, row: int) -> tuple[dict, str]:
         """
         Decrements the packed count for the item at the given row by 1.
 
@@ -1231,7 +1231,7 @@ class PackerLogic(QObject):
         self._save_session_state_async()
         return {"row": row, "packed": item['packed']}, "ITEM_DECREMENTED"
 
-    def force_confirm_item(self, row: int) -> Tuple[Dict, str]:
+    def force_confirm_item(self, row: int) -> tuple[dict, str]:
         """
         Forces an item row to fully packed (packed = required).
 
@@ -1251,7 +1251,7 @@ class PackerLogic(QObject):
 
         # Add a scan record for the force-confirmed quantity (remaining unpacked qty).
         # This ensures _complete_current_order() sees a full items list with timestamps.
-        from shared.metadata_utils import get_current_timestamp, calculate_duration
+        from shared.metadata_utils import calculate_duration, get_current_timestamp
         force_timestamp = get_current_timestamp()
         time_from_start = (
             calculate_duration(self.current_order_start_time, force_timestamp)
@@ -1307,7 +1307,7 @@ class PackerLogic(QObject):
         if total > 0 and (done + skipped) >= total:
             self.all_orders_complete.emit()
 
-    def confirm_keep_extra(self, normalized_sku: str) -> Tuple[Dict, str]:
+    def confirm_keep_extra(self, normalized_sku: str) -> tuple[dict, str]:
         """
         Acknowledges an extra item as intentionally included.
         Removes it from current_extra_items and checks if order can complete.
@@ -1317,7 +1317,7 @@ class PackerLogic(QObject):
         self.current_extra_items.pop(normalized_sku, None)
         return self._maybe_complete_after_extra_resolution()
 
-    def remove_extra_item(self, normalized_sku: str) -> Tuple[Dict, str]:
+    def remove_extra_item(self, normalized_sku: str) -> tuple[dict, str]:
         """
         Marks one extra item of a SKU as removed (acknowledged as a mistake).
         Decrements extra count; removes the key when count reaches 0.
@@ -1331,7 +1331,7 @@ class PackerLogic(QObject):
             self.current_extra_items.pop(normalized_sku, None)
         return self._maybe_complete_after_extra_resolution()
 
-    def _maybe_complete_after_extra_resolution(self) -> Tuple[Dict, str]:
+    def _maybe_complete_after_extra_resolution(self) -> tuple[dict, str]:
         """
         After an extra item is kept/removed, check if all extras are resolved
         and complete the order if so.
@@ -1356,7 +1356,7 @@ class PackerLogic(QObject):
         self._save_session_state_sync()  # Checkpoint: order now complete
         return {}, "ORDER_NOW_COMPLETE"
 
-    def load_packing_list_json(self, packing_list_path: Path) -> Tuple[int, str]:
+    def load_packing_list_json(self, packing_list_path: Path) -> tuple[int, str]:
         """
         Завантажити конкретний пакінг лист з JSON файлу.
 
@@ -1413,11 +1413,11 @@ class PackerLogic(QObject):
 
         except json.JSONDecodeError as e:
             error_msg = f"Invalid JSON in packing list file: {e}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise ValueError(error_msg)
         except Exception as e:
             error_msg = f"Error reading packing list file: {e}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise ValueError(error_msg)
 
         # Extract orders list
@@ -1547,10 +1547,10 @@ class PackerLogic(QObject):
 
         except Exception as e:
             error_msg = f"Error generating barcodes from packing list: {e}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise RuntimeError(error_msg)
 
-    def load_from_shopify_analysis(self, session_path: Path) -> Tuple[int, str]:
+    def load_from_shopify_analysis(self, session_path: Path) -> tuple[int, str]:
         """
         Load orders data from Shopify Tool's analysis_data.json.
 
@@ -1611,11 +1611,11 @@ class PackerLogic(QObject):
 
         except json.JSONDecodeError as e:
             error_msg = f"Invalid JSON in analysis_data.json: {e}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise ValueError(error_msg)
         except Exception as e:
             error_msg = f"Error reading analysis_data.json: {e}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise ValueError(error_msg)
 
         # Extract orders list
@@ -1733,13 +1733,13 @@ class PackerLogic(QObject):
 
         except Exception as e:
             error_msg = f"Error loading Shopify data: {e}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise RuntimeError(error_msg)
 
     def generate_session_summary(
         self,
-        worker_id: str = None,
-        worker_name: str = None,
+        worker_id: str | None = None,
+        worker_name: str | None = None,
         session_type: str = "shopify"
     ) -> dict:
         """
@@ -1786,7 +1786,7 @@ class PackerLogic(QObject):
             "orders": []
         }
         """
-        from shared.metadata_utils import get_current_timestamp, calculate_duration
+        from shared.metadata_utils import calculate_duration, get_current_timestamp
 
         logger.info("Generating session summary (v1.3.0 format)")
 
@@ -1800,7 +1800,7 @@ class PackerLogic(QObject):
                 # Fallback to old method if calculate_duration fails
                 try:
                     started_dt = datetime.fromisoformat(self.started_at)
-                    completed_dt = datetime.now()
+                    completed_dt = datetime.now().astimezone()
                     duration_seconds = int((completed_dt - started_dt).total_seconds())
                 except (ValueError, TypeError) as e:
                     logger.warning(f"Could not parse started_at for duration calculation: {e}")
@@ -1933,9 +1933,9 @@ class PackerLogic(QObject):
 
     def save_session_summary(
         self,
-        summary_path: str = None,
-        worker_id: str = None,
-        worker_name: str = None,
+        summary_path: str | None = None,
+        worker_id: str | None = None,
+        worker_name: str | None = None,
         session_type: str = "shopify"
     ) -> str:
         """
@@ -1974,8 +1974,8 @@ class PackerLogic(QObject):
             return summary_path
 
         except Exception as e:
-            logger.error(f"Failed to save session summary: {e}", exc_info=True)
-            raise IOError(f"Failed to save session summary: {e}")
+            logger.exception("Failed to save session summary")
+            raise OSError(f"Failed to save session summary: {e}")
 
     def end_session_cleanup(self):
         """

--- a/src/packer_logic.py
+++ b/src/packer_logic.py
@@ -374,6 +374,13 @@ class PackerLogic(QObject):
                 # Could be new format (with metadata) or old direct format
                 state_data = data
 
+            if not isinstance(state_data, dict):
+                # Valid JSON (e.g. [], null, a bare string/number) but not an object -
+                # treat as corrupt state rather than let .get()/`in` below raise.
+                logger.error("Session state root is not an object, starting fresh")
+                self.session_packing_state = {'in_progress': {}, 'completed_orders': [], 'skipped_orders': [], 'skipped_orders_timing': {}}
+                return
+
             # Load core packing state with validation
             # CRITICAL FIX: Validate in_progress structure to prevent AttributeError on resume
             raw_in_progress = state_data.get('in_progress', {})

--- a/src/packer_mode_widget.py
+++ b/src/packer_mode_widget.py
@@ -2,14 +2,29 @@ import logging
 import os
 from collections import defaultdict
 from functools import partial
+from typing import Any
+
+from PySide6.QtCore import QSize, Qt, Signal
+from PySide6.QtGui import QColor, QFont, QPalette
 from PySide6.QtWidgets import (
-    QWidget, QHBoxLayout, QVBoxLayout, QTableWidget, QTableWidgetItem,
-    QLabel, QLineEdit, QHeaderView, QPushButton, QAbstractItemView, QFrame,
-    QGroupBox, QProgressBar, QMessageBox, QApplication, QStyle, QTabWidget
+    QAbstractItemView,
+    QApplication,
+    QFrame,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QStyle,
+    QTableWidget,
+    QTableWidgetItem,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
 )
-from PySide6.QtGui import QFont, QColor, QPalette, QIcon
-from PySide6.QtCore import Qt, Signal, QSize
-from typing import List, Dict, Any
 
 from packer_logic import normalize_sku
 
@@ -451,10 +466,10 @@ class PackerModeWidget(QWidget):
 
     def display_order(
         self,
-        items: List[Dict[str, Any]],
-        order_state: List[Dict[str, Any]],
-        metadata: Dict[str, Any] = None,
-        sku_map: Dict[str, str] = None,
+        items: list[dict[str, Any]],
+        order_state: list[dict[str, Any]],
+        metadata: dict[str, Any] | None = None,
+        sku_map: dict[str, str] | None = None,
     ):
         """
         Populates the items table with the details of the current order.
@@ -558,7 +573,7 @@ class PackerModeWidget(QWidget):
             if cell_widget:
                 for btn in cell_widget.findChildren(QPushButton):
                     tip = btn.toolTip()
-                    if tip in ("Confirm Manually", "Force confirm all remaining quantity (qty > 5 only)"):  # noqa: E501
+                    if tip in ("Confirm Manually", "Force confirm all remaining quantity (qty > 5 only)"):
                         btn.setEnabled(False)
         else:
             # Re-apply amber highlight for multi-qty items still in progress
@@ -653,7 +668,7 @@ class PackerModeWidget(QWidget):
 
     # [J] Feature J ────────────────────────────────────────────────────────────
 
-    def show_extras_panel(self, extras: Dict[str, int]):
+    def show_extras_panel(self, extras: dict[str, int]):
         """
         Populates and shows the extras panel with Keep/Remove buttons.
 
@@ -700,7 +715,7 @@ class PackerModeWidget(QWidget):
         row: int,
         sku: str,
         required_qty: int,
-        sku_map: Dict[str, str],
+        sku_map: dict[str, str],
     ) -> QWidget:
         """
         Builds the multi-button widget for the Actions column.
@@ -771,7 +786,7 @@ class PackerModeWidget(QWidget):
         layout.addStretch()
         return container
 
-    def _update_metadata_banner(self, metadata: Dict[str, Any] = None):
+    def _update_metadata_banner(self, metadata: dict[str, Any] | None = None):
         """Populate and show/hide the order metadata banner as chip labels."""
         if not metadata:
             self.metadata_banner.setVisible(False)
@@ -817,17 +832,17 @@ class PackerModeWidget(QWidget):
 
     def _update_summary_panel(
         self,
-        items: List[Dict[str, Any]],
-        order_state: List[Dict[str, Any]],
+        items: list[dict[str, Any]],
+        order_state: list[dict[str, Any]],
     ):
         """
         Deduplicates items by SKU and updates the summary table with summed quantities.
         This handles duplicate SKU rows that can appear in Shopify exports.
         Columns: SKU | Product | Packed/Total | Status
         """
-        sku_totals: Dict[str, int] = defaultdict(int)
-        sku_packed: Dict[str, int] = defaultdict(int)
-        sku_name: Dict[str, str] = {}
+        sku_totals: dict[str, int] = defaultdict(int)
+        sku_packed: dict[str, int] = defaultdict(int)
+        sku_name: dict[str, str] = {}
 
         for item in items:
             sku = item.get('SKU', item.get('sku', ''))
@@ -876,9 +891,9 @@ class PackerModeWidget(QWidget):
         if self.summary_table.rowCount() == 0:
             return
 
-        sku_packed: Dict[str, int] = defaultdict(int)
-        sku_totals: Dict[str, int] = defaultdict(int)
-        sku_name: Dict[str, str] = {}
+        sku_packed: dict[str, int] = defaultdict(int)
+        sku_totals: dict[str, int] = defaultdict(int)
+        sku_name: dict[str, str] = {}
 
         for r in range(self.table.rowCount()):
             name_item = self.table.item(r, 0)

--- a/src/profile_manager.py
+++ b/src/profile_manager.py
@@ -5,20 +5,19 @@ This module manages client-specific configurations, SKU mappings, and session
 directories on a centralized file server. It provides robust file locking for
 concurrent access, caching for performance, and connection testing.
 """
+import configparser
+import json
 import logging
 import os
-import json
 import re
 import shutil
 import time
-import configparser
-from pathlib import Path
-from typing import Dict, List, Optional, Tuple
 from datetime import datetime
+from pathlib import Path
 
-from shared.file_lock import locked_file, FileLockError, WINDOWS_LOCKING_AVAILABLE
-from shared.server_connection import resolve_server_path, test_path_reachable
+from shared.file_lock import WINDOWS_LOCKING_AVAILABLE, FileLockError, locked_file
 from shared.logger import setup_logging
+from shared.server_connection import resolve_server_path, test_path_reachable
 
 logger = logging.getLogger(__name__)
 
@@ -72,8 +71,8 @@ class ProfileManager:
         # Cache for loaded configurations (client_id -> (data, timestamp)).
         # Per-instance (not class-level) so two managers pointed at different
         # base_path/file servers never share each other's cached data.
-        self._config_cache: Dict[str, Tuple[Dict, datetime]] = {}
-        self._sku_cache: Dict[str, Tuple[Dict, datetime]] = {}
+        self._config_cache: dict[str, tuple[dict, datetime]] = {}
+        self._sku_cache: dict[str, tuple[dict, datetime]] = {}
 
         # Load configuration
         self.config = self._load_config(config_path)
@@ -140,7 +139,7 @@ class ProfileManager:
         # Ensure directory structure exists
         self._ensure_directories()
 
-        logger.info(f"ProfileManager initialized successfully")
+        logger.info("ProfileManager initialized successfully")
         logger.info(f"Base path: {self.base_path}")
         logger.info(f"Cache dir: {self.cache_dir}")
 
@@ -156,8 +155,8 @@ class ProfileManager:
         try:
             config.read(config_path, encoding='utf-8')
             logger.info(f"Configuration loaded from {config_path}")
-        except Exception as e:
-            logger.error(f"Failed to load config: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to load config")
 
         return config
 
@@ -171,7 +170,7 @@ class ProfileManager:
             self.logs_dir.mkdir(parents=True, exist_ok=True)
             logger.debug("Directory structure verified")
         except Exception as e:
-            logger.error(f"Cannot create directories: {e}", exc_info=True)
+            logger.exception("Cannot create directories")
             raise ProfileManagerError(f"Cannot create directories on file server: {e}")
 
     # ========================================================================
@@ -179,7 +178,7 @@ class ProfileManager:
     # ========================================================================
 
     @staticmethod
-    def validate_client_id(client_id: str) -> Tuple[bool, str]:
+    def validate_client_id(client_id: str) -> tuple[bool, str]:
         """
         Validate client ID format.
 
@@ -222,7 +221,7 @@ class ProfileManager:
     # CLIENT PROFILE MANAGEMENT
     # ========================================================================
 
-    def get_available_clients(self) -> List[str]:
+    def get_available_clients(self) -> list[str]:
         """
         Get list of available client IDs.
 
@@ -243,8 +242,8 @@ class ProfileManager:
             logger.debug(f"Found {len(clients)} clients: {clients}")
             return sorted(clients)
 
-        except Exception as e:
-            logger.error(f"Error listing clients: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Error listing clients")
             return []
 
     def client_exists(self, client_id: str) -> bool:
@@ -289,7 +288,7 @@ class ProfileManager:
             default_packer_config = {
                 "client_id": client_id,
                 "client_name": client_name,
-                "created_at": datetime.now().isoformat(),
+                "created_at": datetime.now().astimezone().isoformat(),
                 "barcode_label": {
                     "width_mm": 65,
                     "height_mm": 35,
@@ -316,7 +315,7 @@ class ProfileManager:
                     "format": "CODE128"
                 },
                 "packing_rules": {},
-                "last_updated": datetime.now().isoformat(),
+                "last_updated": datetime.now().astimezone().isoformat(),
                 "updated_by": os.environ.get('COMPUTERNAME', 'Unknown')
             }
 
@@ -330,7 +329,7 @@ class ProfileManager:
             client_config = {
                 "client_id": client_id,
                 "client_name": client_name,
-                "created_at": datetime.now().isoformat()
+                "created_at": datetime.now().astimezone().isoformat()
             }
 
             client_config_path = client_dir / "client_config.json"
@@ -350,13 +349,13 @@ class ProfileManager:
             return True
 
         except Exception as e:
-            logger.error(f"Failed to create client profile: {e}", exc_info=True)
+            logger.exception("Failed to create client profile")
             # Cleanup on failure
             if client_dir.exists():
                 shutil.rmtree(client_dir, ignore_errors=True)
             raise ProfileManagerError(f"Failed to create client profile: {e}")
 
-    def load_client_config(self, client_id: str) -> Optional[Dict]:
+    def load_client_config(self, client_id: str) -> dict | None:
         """
         Load packer configuration for a specific client with caching.
 
@@ -370,7 +369,7 @@ class ProfileManager:
         cache_key = f"config_{client_id}"
         if cache_key in self._config_cache:
             cached_data, cached_time = self._config_cache[cache_key]
-            age_seconds = (datetime.now() - cached_time).total_seconds()
+            age_seconds = (datetime.now().astimezone() - cached_time).total_seconds()
 
             if age_seconds < self.CACHE_TIMEOUT_SECONDS:
                 logger.debug(f"Using cached config for {client_id}")
@@ -391,16 +390,16 @@ class ProfileManager:
                 config = json.load(f)
 
             # Update cache
-            self._config_cache[cache_key] = (config, datetime.now())
+            self._config_cache[cache_key] = (config, datetime.now().astimezone())
 
             logger.debug(f"Loaded config for client {client_id} from {path_to_use.name}")
             return config.copy()
 
-        except Exception as e:
-            logger.error(f"Error loading config for {client_id}: {e}", exc_info=True)
+        except Exception:
+            logger.exception(f"Error loading config for {client_id}")
             return None
 
-    def save_client_config(self, client_id: str, config: Dict) -> bool:
+    def save_client_config(self, client_id: str, config: dict) -> bool:
         """
         Save packer configuration for a specific client with backup.
 
@@ -419,7 +418,7 @@ class ProfileManager:
                 self._create_backup(client_id, packer_config_path, "packer_config")
 
             # Update timestamp
-            config['last_updated'] = datetime.now().isoformat()
+            config['last_updated'] = datetime.now().astimezone().isoformat()
             config['updated_by'] = os.environ.get('COMPUTERNAME', 'Unknown')
 
             # Save new config
@@ -433,8 +432,8 @@ class ProfileManager:
             logger.info(f"Saved packer_config for client {client_id}")
             return True
 
-        except Exception as e:
-            logger.error(f"Error saving config for {client_id}: {e}", exc_info=True)
+        except Exception:
+            logger.exception(f"Error saving config for {client_id}")
             return False
 
     def _create_backup(self, client_id: str, file_path: Path, file_type: str):
@@ -442,7 +441,7 @@ class ProfileManager:
         backup_dir = self.clients_dir / f"CLIENT_{client_id}" / "backups"
         backup_dir.mkdir(exist_ok=True)
 
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        timestamp = datetime.now().astimezone().strftime("%Y%m%d_%H%M%S")
         backup_path = backup_dir / f"{file_type}_{timestamp}.json"
 
         try:
@@ -462,7 +461,7 @@ class ProfileManager:
     # SKU MAPPING WITH FILE LOCKING
     # ========================================================================
 
-    def load_sku_mapping(self, client_id: str) -> Dict[str, str]:
+    def load_sku_mapping(self, client_id: str) -> dict[str, str]:
         """
         Load SKU mapping for a specific client with caching.
         Now reads from packer_config.json instead of separate sku_mapping.json
@@ -477,7 +476,7 @@ class ProfileManager:
         cache_key = f"sku_{client_id}"
         if cache_key in self._sku_cache:
             cached_data, cached_time = self._sku_cache[cache_key]
-            age_seconds = (datetime.now() - cached_time).total_seconds()
+            age_seconds = (datetime.now().astimezone() - cached_time).total_seconds()
 
             if age_seconds < self.CACHE_TIMEOUT_SECONDS:
                 logger.debug(f"Using cached SKU mapping for {client_id}")
@@ -496,8 +495,8 @@ class ProfileManager:
                     data = json.load(f)
                     mappings = data.get("sku_mapping", {})
                 logger.debug(f"Loaded {len(mappings)} SKU mappings from packer_config for {client_id}")
-            except Exception as e:
-                logger.error(f"Error loading SKU mapping from packer_config for {client_id}: {e}", exc_info=True)
+            except Exception:
+                logger.exception(f"Error loading SKU mapping from packer_config for {client_id}")
 
         # Fall back to old sku_mapping.json if packer_config doesn't have mappings
         if not mappings and mapping_path.exists():
@@ -506,15 +505,15 @@ class ProfileManager:
                     data = json.load(f)
                     mappings = data.get("mappings", {})
                 logger.debug(f"Loaded {len(mappings)} SKU mappings from sku_mapping.json for {client_id}")
-            except Exception as e:
-                logger.error(f"Error loading SKU mapping from sku_mapping.json for {client_id}: {e}", exc_info=True)
+            except Exception:
+                logger.exception(f"Error loading SKU mapping from sku_mapping.json for {client_id}")
 
         # Update cache
-        self._sku_cache[cache_key] = (mappings, datetime.now())
+        self._sku_cache[cache_key] = (mappings, datetime.now().astimezone())
 
         return mappings.copy()
 
-    def save_sku_mapping(self, client_id: str, mappings: Dict[str, str]) -> bool:
+    def save_sku_mapping(self, client_id: str, mappings: dict[str, str]) -> bool:
         """
         Save SKU mapping to packer_config.json with file locking and merge support.
 
@@ -556,24 +555,23 @@ class ProfileManager:
                     with open(packer_config_path, 'w', encoding='utf-8') as f:
                         json.dump(default_config, f)
 
-                with open(packer_config_path, 'r+', encoding='utf-8') as f:
-                    with locked_file(f):
-                        # Read current data
-                        f.seek(0)
-                        current_data = json.load(f)
+                with open(packer_config_path, 'r+', encoding='utf-8') as f, locked_file(f):
+                    # Read current data
+                    f.seek(0)
+                    current_data = json.load(f)
 
-                        # Replace (not merge): callers pass the full desired mapping,
-                        # so a deleted entry must not survive by merging onto disk.
-                        current_data['sku_mapping'] = mappings
-                        current_data['last_updated'] = datetime.now().isoformat()
-                        current_data['updated_by'] = os.environ.get('COMPUTERNAME', 'Unknown')
+                    # Replace (not merge): callers pass the full desired mapping,
+                    # so a deleted entry must not survive by merging onto disk.
+                    current_data['sku_mapping'] = mappings
+                    current_data['last_updated'] = datetime.now().astimezone().isoformat()
+                    current_data['updated_by'] = os.environ.get('COMPUTERNAME', 'Unknown')
 
-                        # Write back (truncate and write)
-                        f.seek(0)
-                        f.truncate()
-                        json.dump(current_data, f, indent=2, ensure_ascii=False)
+                    # Write back (truncate and write)
+                    f.seek(0)
+                    f.truncate()
+                    json.dump(current_data, f, indent=2, ensure_ascii=False)
 
-                        logger.info(f"Successfully saved SKU mapping to packer_config for {client_id}")
+                    logger.info(f"Successfully saved SKU mapping to packer_config for {client_id}")
 
                 # Invalidate caches
                 cache_key = f"sku_{client_id}"
@@ -583,24 +581,24 @@ class ProfileManager:
 
                 return True
 
-            except (IOError, FileLockError) as e:
+            except (OSError, FileLockError):
                 # File is locked by another process
                 if attempt < max_retries - 1:
                     logger.warning(f"packer_config locked, retry {attempt + 1}/{max_retries}")
                     time.sleep(retry_delay)
                 else:
-                    logger.error(f"Could not acquire lock on packer_config after {max_retries} attempts", exc_info=True)
+                    logger.exception(f"Could not acquire lock on packer_config after {max_retries} attempts")
                     raise ProfileManagerError(
-                        f"Configuration is locked by another user. Please try again in a moment."
+                        "Configuration is locked by another user. Please try again in a moment."
                     )
 
             except Exception as e:
-                logger.error(f"Error saving SKU mapping: {e}", exc_info=True)
+                logger.exception("Error saving SKU mapping")
                 raise ProfileManagerError(f"Failed to save SKU mapping: {e}")
 
         return False
 
-    def _save_sku_mapping_simple(self, client_id: str, mappings: Dict[str, str]) -> bool:
+    def _save_sku_mapping_simple(self, client_id: str, mappings: dict[str, str]) -> bool:
         """
         Simple save without file locking (fallback).
         Saves to packer_config.json
@@ -628,7 +626,7 @@ class ProfileManager:
             # Replace (not merge): callers pass the full desired mapping, so a
             # deleted entry must not survive by merging onto disk.
             current_config['sku_mapping'] = mappings
-            current_config['last_updated'] = datetime.now().isoformat()
+            current_config['last_updated'] = datetime.now().astimezone().isoformat()
             current_config['updated_by'] = os.environ.get('COMPUTERNAME', 'Unknown')
 
             # Save
@@ -644,15 +642,15 @@ class ProfileManager:
             logger.info(f"Saved SKU mapping to packer_config for {client_id} (simple mode)")
             return True
 
-        except Exception as e:
-            logger.error(f"Error saving SKU mapping (simple): {e}", exc_info=True)
+        except Exception:
+            logger.exception("Error saving SKU mapping (simple)")
             return False
 
     # ========================================================================
     # SESSION MANAGEMENT
     # ========================================================================
 
-    def get_session_dir(self, client_id: str, session_name: Optional[str] = None) -> Path:
+    def get_session_dir(self, client_id: str, session_name: str | None = None) -> Path:
         """
         Get session directory path for a client.
 
@@ -670,10 +668,10 @@ class ProfileManager:
             return client_sessions / session_name
 
         # Generate new session name with timestamp
-        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M")
+        timestamp = datetime.now().astimezone().strftime("%Y-%m-%d_%H-%M")
         return client_sessions / timestamp
 
-    def get_incomplete_sessions(self, client_id: str) -> List[Path]:
+    def get_incomplete_sessions(self, client_id: str) -> list[Path]:
         """
         Get list of incomplete sessions for a client.
 
@@ -710,11 +708,11 @@ class ProfileManager:
             logger.debug(f"Found {len(incomplete_sessions)} incomplete sessions for client {client_id}")
             return incomplete_sessions
 
-        except Exception as e:
-            logger.error(f"Error getting incomplete sessions for {client_id}: {e}", exc_info=True)
+        except Exception:
+            logger.exception(f"Error getting incomplete sessions for {client_id}")
             return []
 
-    def list_clients(self) -> List[str]:
+    def list_clients(self) -> list[str]:
         """
         Get list of all client IDs.
 
@@ -740,8 +738,8 @@ class ProfileManager:
             logger.debug(f"Found {len(clients)} clients")
             return sorted(clients)
 
-        except Exception as e:
-            logger.error(f"Error listing clients: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Error listing clients")
             return []
 
     def get_sessions_root(self) -> Path:

--- a/src/restore_session_dialog.py
+++ b/src/restore_session_dialog.py
@@ -2,15 +2,20 @@
 Restore Session Dialog - UI for selecting incomplete sessions with lock status.
 """
 
-from pathlib import Path
-from typing import Optional
-from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QLabel, QListWidget, QListWidgetItem,
-    QPushButton, QHBoxLayout, QMessageBox
-)
-from PySide6.QtCore import Qt
-
 import logging
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +139,7 @@ class RestoreSessionDialog(QDialog):
             logger.info(f"Loaded {len(sessions)} incomplete sessions for client {self.client_id}")
 
         except Exception as e:
-            logger.error(f"Failed to load sessions: {e}", exc_info=True)
+            logger.exception("Failed to load sessions")
             QMessageBox.warning(
                 self,
                 "Error",
@@ -206,7 +211,7 @@ class RestoreSessionDialog(QDialog):
                         )
                         return
                 except Exception as e:
-                    logger.error(f"Error force-releasing lock: {e}", exc_info=True)
+                    logger.exception("Error force-releasing lock")
                     QMessageBox.critical(self, "Error", f"Failed to release lock:\n\n{e}")
                     return
             else:
@@ -216,7 +221,7 @@ class RestoreSessionDialog(QDialog):
         self.selected_session = session_dir
         self.accept()
 
-    def get_selected_session(self) -> Optional[Path]:
+    def get_selected_session(self) -> Path | None:
         """
         Get the selected session directory.
 

--- a/src/session_browser/__init__.py
+++ b/src/session_browser/__init__.py
@@ -4,12 +4,12 @@ Provides a fast session browser backed by per-client registry_index.json files.
 Session load time is < 1 second regardless of total session count.
 """
 
-from .session_browser_widget import SessionBrowserWidget
 from .client_selector_widget import ClientSelectorWidget
+from .session_browser_widget import SessionBrowserWidget
 from .sessions_list_widget import SessionsListWidget
 
 __all__ = [
-    'SessionBrowserWidget',
     'ClientSelectorWidget',
+    'SessionBrowserWidget',
     'SessionsListWidget',
 ]

--- a/src/session_browser/client_selector_widget.py
+++ b/src/session_browser/client_selector_widget.py
@@ -6,13 +6,18 @@ the user picks one.  The selection is persisted in QSettings so the
 last-used client is auto-restored on the next open.
 """
 
-from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QLabel, QListWidget, QListWidgetItem,
-    QPushButton, QFrame
-)
-from PySide6.QtCore import Signal, Qt, QSettings
-
 import logging
+
+from PySide6.QtCore import QSettings, Qt, Signal
+from PySide6.QtWidgets import (
+    QFrame,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -72,8 +77,8 @@ class ClientSelectorWidget(QWidget):
         """Fetch client list from ProfileManager and populate the list."""
         try:
             clients = self.profile_manager.list_clients()
-        except Exception as e:
-            logger.error(f"Failed to list clients: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to list clients")
             clients = []
 
         saved = self._settings.value("last_client_id", "", type=str)

--- a/src/session_browser/metrics_tab.py
+++ b/src/session_browser/metrics_tab.py
@@ -1,10 +1,14 @@
 """Metrics Tab - Performance statistics and rates"""
 
-from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QFormLayout, QLabel,
-    QGroupBox, QScrollArea
-)
 from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QFormLayout,
+    QGroupBox,
+    QLabel,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
 
 
 class MetricsTab(QWidget):

--- a/src/session_browser/orders_tab.py
+++ b/src/session_browser/orders_tab.py
@@ -1,14 +1,20 @@
 """Orders Tab - Hierarchical view of orders and items with timing data"""
 
-from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QPushButton,
-    QTreeWidget, QTreeWidgetItem, QLabel, QLineEdit
-)
+import logging
+from datetime import datetime
+
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
-
-from datetime import datetime
-import logging
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/session_browser/overview_tab.py
+++ b/src/session_browser/overview_tab.py
@@ -1,11 +1,8 @@
 """Overview Tab - Session metadata and summary"""
 
-from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QFormLayout, QLabel,
-    QGroupBox
-)
-
 from datetime import datetime
+
+from PySide6.QtWidgets import QFormLayout, QGroupBox, QLabel, QVBoxLayout, QWidget
 
 
 class OverviewTab(QWidget):

--- a/src/session_browser/session_browser_widget.py
+++ b/src/session_browser/session_browser_widget.py
@@ -20,15 +20,18 @@ Migration: on first open for a client, if no registry file exists, a one-time
 directory scan builds the registry.  Shown as "Building session index…".
 """
 
+import logging
 import time
 
+from PySide6.QtCore import QSettings, Qt, QTimer, Signal
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
-    QCheckBox, QSplitter, QFrame
+    QCheckBox,
+    QHBoxLayout,
+    QSplitter,
+    QVBoxLayout,
+    QWidget,
 )
-from PySide6.QtCore import Signal, QTimer, Qt, QSettings
 
-import logging
 from .client_selector_widget import ClientSelectorWidget
 from .sessions_list_widget import SessionsListWidget
 

--- a/src/session_browser/session_details_dialog.py
+++ b/src/session_browser/session_details_dialog.py
@@ -1,19 +1,25 @@
 """Session Details Dialog - Detailed view of session with orders, items, metrics"""
 
-from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QTabWidget,
-    QPushButton, QMessageBox, QFileDialog
-)
-
-from .overview_tab import OverviewTab
-from .orders_tab import OrdersTab
-from .metrics_tab import MetricsTab
-
-from pathlib import Path
 import json
 import logging
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QFileDialog,
+    QHBoxLayout,
+    QMessageBox,
+    QPushButton,
+    QTabWidget,
+    QVBoxLayout,
+)
+
 from json_cache import get_cached_json
 from packer_logic import compute_order_timing_metrics
+
+from .metrics_tab import MetricsTab
+from .orders_tab import OrdersTab
+from .overview_tab import OverviewTab
 
 logger = logging.getLogger(__name__)
 
@@ -256,11 +262,11 @@ class SessionDetailsDialog(QDialog):
             )
 
         except Exception as e:
-            logger.error(f"Failed to export: {e}", exc_info=True)
+            logger.exception("Failed to export")
             QMessageBox.critical(
                 self,
                 "Export Failed",
-                f"Failed to export session details:\n{str(e)}"
+                f"Failed to export session details:\n{e!s}"
             )
 
     def _get_orders_for_export(self) -> list:

--- a/src/session_browser/sessions_list_widget.py
+++ b/src/session_browser/sessions_list_widget.py
@@ -13,19 +13,27 @@ Filter / search works purely on already-loaded table data (no server I/O).
 """
 
 import csv
-import os
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import Optional
-
-from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton,
-    QTableWidget, QTableWidgetItem, QHeaderView, QComboBox,
-    QFileDialog, QMessageBox, QDateEdit, QFrame, QSizePolicy, QProgressBar
-)
-from PySide6.QtCore import Signal, Qt, QThread, QDate, QSize
-
 import logging
+from datetime import datetime
+
+from PySide6.QtCore import QDate, Qt, QThread, Signal
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDateEdit,
+    QFileDialog,
+    QFrame,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
 from shared.metadata_utils import parse_timestamp
 from shared.theme import StatusDot
 
@@ -97,7 +105,7 @@ class RegistryRefreshWorker(QThread):
             entries = self._registry.get_all_entries(self._client_id)
             self.refresh_complete.emit(self._client_id, entries)
         except Exception as exc:
-            logger.error(f"RegistryRefreshWorker failed: {exc}", exc_info=True)
+            logger.exception("RegistryRefreshWorker failed")
             self.refresh_failed.emit(self._client_id, str(exc))
 
 
@@ -105,7 +113,7 @@ class RegistryRefreshWorker(QThread):
 #  Helper functions                                                    #
 # ------------------------------------------------------------------ #
 
-def _fmt_duration(seconds: Optional[float]) -> str:
+def _fmt_duration(seconds: float | None) -> str:
     if not seconds:
         return "—"
     h = int(seconds // 3600)
@@ -118,7 +126,7 @@ def _fmt_duration(seconds: Optional[float]) -> str:
     return f"{s}s"
 
 
-def _fmt_date(ts_str: Optional[str]) -> str:
+def _fmt_date(ts_str: str | None) -> str:
     if not ts_str:
         return "—"
     dt = parse_timestamp(ts_str)
@@ -162,9 +170,9 @@ class SessionsListWidget(QWidget):
         super().__init__(parent)
         self._registry = registry_manager
         self._history_mgr = session_history_manager
-        self._client_id: Optional[str] = None
+        self._client_id: str | None = None
         self._all_entries: list = []
-        self._refresh_worker: Optional[RegistryRefreshWorker] = None
+        self._refresh_worker: RegistryRefreshWorker | None = None
 
         self._init_ui()
 
@@ -365,7 +373,7 @@ class SessionsListWidget(QWidget):
         self._populate_table(entries)
         self._update_header_stats(entries)
         self._status_bar.setText(
-            f"Last refreshed: {datetime.now().strftime('%H:%M:%S')}  "
+            f"Last refreshed: {datetime.now().astimezone().strftime('%H:%M:%S')}  "
             f"({len(entries)} entries)"
         )
 
@@ -539,7 +547,7 @@ class SessionsListWidget(QWidget):
     #  Row selection / preview panel                                       #
     # ------------------------------------------------------------------ #
 
-    def _get_row_entry(self, row: int) -> Optional[dict]:
+    def _get_row_entry(self, row: int) -> dict | None:
         if row < 0:
             return None
         item = self._table.item(row, COL_STATUS)
@@ -639,7 +647,7 @@ class SessionsListWidget(QWidget):
             )
             dlg.exec()
         except Exception as e:
-            logger.error(f"Failed to open session details: {e}", exc_info=True)
+            logger.exception("Failed to open session details")
             QMessageBox.warning(self, "Error", f"Could not load session details:\n{e}")
 
     def _emit_resume_session(self, entry: dict):

--- a/src/session_history_manager.py
+++ b/src/session_history_manager.py
@@ -4,13 +4,12 @@ Session History Manager - Manages historical session data and analytics.
 This module provides functionality to retrieve, analyze, and search through
 completed packing sessions, enabling historical reporting and analytics.
 """
-import json
-from pathlib import Path
-from datetime import datetime
-from typing import List, Dict, Any, Optional
-from dataclasses import dataclass, asdict
-
 import logging
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
 from json_cache import get_cached_json
 
 logger = logging.getLogger(__name__)
@@ -39,20 +38,20 @@ class SessionHistoryRecord:
     """
     session_id: str
     client_id: str
-    start_time: Optional[datetime]
-    end_time: Optional[datetime]
-    duration_seconds: Optional[float]
+    start_time: datetime | None
+    end_time: datetime | None
+    duration_seconds: float | None
     total_orders: int
     completed_orders: int
     in_progress_orders: int
     total_items_packed: int
-    worker_id: Optional[str] = None
-    worker_name: Optional[str] = None
-    pc_name: Optional[str] = None
-    packing_list_path: Optional[str] = None
+    worker_id: str | None = None
+    worker_name: str | None = None
+    pc_name: str | None = None
+    packing_list_path: str | None = None
     session_path: str = ""
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary with datetime objects as ISO strings."""
         data = asdict(self)
         if self.start_time:
@@ -84,7 +83,7 @@ class SessionHistoryManager:
         self,
         client_id: str,
         session_dir: Path
-    ) -> List[SessionHistoryRecord]:
+    ) -> list[SessionHistoryRecord]:
         """
         Parse a session directory and extract metrics for all packing lists.
 
@@ -170,7 +169,7 @@ class SessionHistoryManager:
         client_id: str,
         session_dir: Path,
         summary_file: Path
-    ) -> Optional[SessionHistoryRecord]:
+    ) -> SessionHistoryRecord | None:
         """
         Parse session_summary.json for completed sessions (v1.3.0 format only).
 
@@ -217,8 +216,8 @@ class SessionHistoryManager:
                 session_path=str(session_dir)
             )
 
-        except Exception as e:
-            logger.error(f"Error parsing session summary {session_id}: {e}", exc_info=True)
+        except Exception:
+            logger.exception(f"Error parsing session summary {session_id}")
             return None
 
     def _parse_packing_state(
@@ -226,7 +225,7 @@ class SessionHistoryManager:
         client_id: str,
         session_dir: Path,
         state_file: Path
-    ) -> Optional[SessionHistoryRecord]:
+    ) -> SessionHistoryRecord | None:
         """
         Parse packing_state.json for in-progress or completed sessions.
 
@@ -290,8 +289,8 @@ class SessionHistoryManager:
                     end_time = datetime.fromtimestamp(mtime, tz=timezone.utc)
                     if start_time:
                         duration_seconds = (end_time - start_time).total_seconds()
-                except Exception:
-                    pass
+                except Exception as mtime_exc:
+                    logger.debug(f"Could not derive end_time from file mtime: {mtime_exc}")
 
             # Extract session info details
             pc_name = session_info.get('pc_name') if session_info else None
@@ -318,11 +317,11 @@ class SessionHistoryManager:
                 session_path=str(session_dir)
             )
 
-        except Exception as e:
-            logger.error(f"Error parsing packing_state.json for {session_id}: {e}", exc_info=True)
+        except Exception:
+            logger.exception(f"Error parsing packing_state.json for {session_id}")
             return None
 
-    def _load_session_info(self, session_dir: Path) -> Optional[Dict[str, Any]]:
+    def _load_session_info(self, session_dir: Path) -> dict[str, Any] | None:
         """Load session_info.json if it exists."""
         info_file = session_dir / "session_info.json"
         if info_file.exists():
@@ -334,7 +333,7 @@ class SessionHistoryManager:
                 logger.warning(f"Error reading session_info.json: {e}")
         return None
 
-    def _parse_session_timestamp(self, session_id: str) -> Optional[datetime]:
+    def _parse_session_timestamp(self, session_id: str) -> datetime | None:
         """
         Parse timestamp from session ID.
 
@@ -344,12 +343,13 @@ class SessionHistoryManager:
         from datetime import timezone
         try:
             # Try standard format: YYYYMMDD_HHMMSS
-            dt = datetime.strptime(session_id, "%Y%m%d_%H%M%S")
+            # Session IDs carry no offset, so %z isn't available; made aware below.
+            dt = datetime.strptime(session_id, "%Y%m%d_%H%M%S")  # noqa: DTZ007
             return dt.replace(tzinfo=timezone.utc)
         except ValueError:
             try:
                 # Try alternative formats
-                dt = datetime.strptime(session_id, "%Y%m%d-%H%M%S")
+                dt = datetime.strptime(session_id, "%Y%m%d-%H%M%S")  # noqa: DTZ007
                 return dt.replace(tzinfo=timezone.utc)
             except ValueError:
                 logger.debug(f"Could not parse timestamp from session ID: {session_id}")
@@ -357,8 +357,8 @@ class SessionHistoryManager:
 
     def _count_packed_items(
         self,
-        in_progress: Dict[str, Any],
-        completed: List[str]
+        in_progress: dict[str, Any],
+        completed: list[str]
     ) -> int:
         """
         Count total items packed across all orders.
@@ -388,7 +388,7 @@ class SessionHistoryManager:
         self,
         client_id: str,
         session_id: str
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """
         Get detailed information about a specific session.
 
@@ -466,6 +466,6 @@ class SessionHistoryManager:
                 'session_summary': session_summary
             }
 
-        except Exception as e:
-            logger.error(f"Error getting session details: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Error getting session details")
             return None

--- a/src/session_lock_manager.py
+++ b/src/session_lock_manager.py
@@ -6,16 +6,15 @@ user can work on a session at a time, with crash recovery support.
 """
 
 import json
+import logging
 import os
 import socket
 import time
-from pathlib import Path
 from datetime import datetime
-from typing import Dict, Optional, Tuple
+from pathlib import Path
 
 from shared.atomic_write import atomic_write_json
-from shared.file_lock import locked_file, FileLockError
-import logging
+from shared.file_lock import FileLockError, locked_file
 
 
 class SessionLockManager:
@@ -64,9 +63,9 @@ class SessionLockManager:
         self,
         client_id: str,
         session_dir: Path,
-        worker_id: Optional[str] = None,
-        worker_name: Optional[str] = None
-    ) -> Tuple[bool, Optional[str], Optional[Dict]]:
+        worker_id: str | None = None,
+        worker_name: str | None = None
+    ) -> tuple[bool, str | None, dict | None]:
         """
         Attempt to acquire a lock on the session.
 
@@ -107,7 +106,7 @@ class SessionLockManager:
                     if self.is_lock_stale(lock_info):
                         error_msg = self._format_stale_lock_message(lock_info)
                         self.logger.warning(
-                            f"Session has stale lock",
+                            "Session has stale lock",
                             extra={
                                 "client_id": client_id,
                                 "session_dir": str(session_dir),
@@ -120,7 +119,7 @@ class SessionLockManager:
                         # Active lock by another process
                         error_msg = self._format_active_lock_message(lock_info)
                         self.logger.warning(
-                            f"Attempt to open locked session",
+                            "Attempt to open locked session",
                             extra={
                                 "client_id": client_id,
                                 "session_dir": str(session_dir),
@@ -147,7 +146,7 @@ class SessionLockManager:
             atomic_write_json(lock_path, lock_data, indent=2)
 
             self.logger.info(
-                f"Session lock acquired successfully",
+                "Session lock acquired successfully",
                 extra={
                     "client_id": client_id,
                     "session_dir": str(session_dir),
@@ -158,10 +157,9 @@ class SessionLockManager:
             return True, None, None
 
         except Exception as e:
-            self.logger.error(
-                f"Failed to acquire lock: {e}",
+            self.logger.exception(
+                "Failed to acquire lock",
                 extra={"client_id": client_id, "session_dir": str(session_dir)},
-                exc_info=True
             )
             return False, f"Failed to create lock file: {e}", None
 
@@ -190,14 +188,14 @@ class SessionLockManager:
                     # It's our lock, safe to delete
                     lock_path.unlink()
                     self.logger.info(
-                        f"Session lock released",
+                        "Session lock released",
                         extra={"session_dir": str(session_dir)}
                     )
                     return True
                 else:
                     # Not our lock, don't delete
                     self.logger.warning(
-                        f"Attempted to release lock owned by another process",
+                        "Attempted to release lock owned by another process",
                         extra={
                             "session_dir": str(session_dir),
                             "lock_owner": lock_info.get('locked_by'),
@@ -210,15 +208,14 @@ class SessionLockManager:
                 lock_path.unlink()
                 return True
 
-        except Exception as e:
-            self.logger.error(
-                f"Failed to release lock: {e}",
+        except Exception:
+            self.logger.exception(
+                "Failed to release lock",
                 extra={"session_dir": str(session_dir)},
-                exc_info=True
             )
             return False
 
-    def is_locked(self, session_dir: Path) -> Tuple[bool, Optional[Dict]]:
+    def is_locked(self, session_dir: Path) -> tuple[bool, dict | None]:
         """
         Check if a session is locked.
 
@@ -256,7 +253,7 @@ class SessionLockManager:
 
             return True, lock_info
 
-        except (json.JSONDecodeError, IOError) as e:
+        except (OSError, json.JSONDecodeError) as e:
             self.logger.warning(
                 f"Failed to read lock file: {e}",
                 extra={"session_dir": str(session_dir)}
@@ -280,7 +277,7 @@ class SessionLockManager:
 
         if not lock_path.exists():
             self.logger.warning(
-                f"Cannot update heartbeat: lock file doesn't exist",
+                "Cannot update heartbeat: lock file doesn't exist",
                 extra={"session_dir": str(session_dir)}
             )
             return False
@@ -288,36 +285,35 @@ class SessionLockManager:
         max_retries = 3
         for attempt in range(max_retries):
             try:
-                with open(lock_path, 'r+', encoding='utf-8') as f:
-                    with locked_file(f):
-                        # Read current data
-                        f.seek(0)
-                        data = json.load(f)
+                with open(lock_path, 'r+', encoding='utf-8') as f, locked_file(f):
+                    # Read current data
+                    f.seek(0)
+                    data = json.load(f)
 
-                        # Verify it's our lock
-                        if (data.get('locked_by') != self.hostname or
-                            data.get('process_id') != self.process_id):
-                            self.logger.warning(
-                                f"Attempted to update heartbeat for lock owned by another process",
-                                extra={"session_dir": str(session_dir)}
-                            )
-                            return False
-
-                        # Update heartbeat
-                        data['heartbeat'] = datetime.now().astimezone().isoformat()
-
-                        # Write back
-                        f.seek(0)
-                        f.truncate()
-                        json.dump(data, f, indent=2)
-
-                        self.logger.debug(
-                            f"Heartbeat updated",
+                    # Verify it's our lock
+                    if (data.get('locked_by') != self.hostname or
+                        data.get('process_id') != self.process_id):
+                        self.logger.warning(
+                            "Attempted to update heartbeat for lock owned by another process",
                             extra={"session_dir": str(session_dir)}
                         )
-                        return True
+                        return False
 
-            except (IOError, OSError, FileLockError, json.JSONDecodeError) as e:
+                    # Update heartbeat
+                    data['heartbeat'] = datetime.now().astimezone().isoformat()
+
+                    # Write back
+                    f.seek(0)
+                    f.truncate()
+                    json.dump(data, f, indent=2)
+
+                    self.logger.debug(
+                        "Heartbeat updated",
+                        extra={"session_dir": str(session_dir)}
+                    )
+                    return True
+
+            except (OSError, FileLockError, json.JSONDecodeError) as e:
                 # Network issue or file error - don't crash
                 self.logger.warning(
                     f"Failed to update heartbeat (attempt {attempt + 1}/{max_retries}): {e}",
@@ -330,7 +326,7 @@ class SessionLockManager:
 
         return False
 
-    def is_lock_stale(self, lock_info: Dict) -> bool:
+    def is_lock_stale(self, lock_info: dict) -> bool:
         """
         Check if a lock is stale (no recent heartbeat).
 
@@ -377,7 +373,7 @@ class SessionLockManager:
 
         try:
             # Get lock info for logging
-            is_locked, lock_info = self.is_locked(session_dir)
+            _is_locked, lock_info = self.is_locked(session_dir)
 
             # Delete the lock file
             lock_path.unlink()
@@ -385,7 +381,7 @@ class SessionLockManager:
             if lock_info:
                 stale_minutes = self._get_stale_minutes(lock_info)
                 self.logger.warning(
-                    f"Stale lock force-released",
+                    "Stale lock force-released",
                     extra={
                         "session_dir": str(session_dir),
                         "original_lock_by": lock_info.get('locked_by'),
@@ -395,21 +391,20 @@ class SessionLockManager:
                 )
             else:
                 self.logger.info(
-                    f"Invalid lock file removed",
+                    "Invalid lock file removed",
                     extra={"session_dir": str(session_dir)}
                 )
 
             return True
 
-        except Exception as e:
-            self.logger.error(
-                f"Failed to force-release lock: {e}",
+        except Exception:
+            self.logger.exception(
+                "Failed to force-release lock",
                 extra={"session_dir": str(session_dir)},
-                exc_info=True
             )
             return False
 
-    def _get_stale_minutes(self, lock_info: Dict) -> int:
+    def _get_stale_minutes(self, lock_info: dict) -> int:
         """Get how many minutes the lock has been stale."""
         try:
             heartbeat_str = lock_info.get('heartbeat')
@@ -427,7 +422,7 @@ class SessionLockManager:
         except (ValueError, TypeError):
             return 0
 
-    def _format_active_lock_message(self, lock_info: Dict) -> str:
+    def _format_active_lock_message(self, lock_info: dict) -> str:
         """Format error message for active lock."""
         locked_by = lock_info.get('locked_by', 'Unknown PC')
         user_name = lock_info.get('user_name', 'Unknown user')
@@ -438,7 +433,7 @@ class SessionLockManager:
             f"Please wait or choose another session."
         )
 
-    def _format_stale_lock_message(self, lock_info: Dict) -> str:
+    def _format_stale_lock_message(self, lock_info: dict) -> str:
         """Format error message for stale lock."""
         locked_by = lock_info.get('locked_by', 'Unknown PC')
         user_name = lock_info.get('user_name', 'Unknown user')

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -20,17 +20,16 @@ For small warehouse operations, this module ensures that:
 """
 
 # Standard library imports
-import os  # For environment variables (PC name)
 import json  # For session info persistence
-from pathlib import Path  # Modern path handling
-from typing import Optional  # Type hints
-
-from shared.atomic_write import atomic_write_json
-from shared.metadata_utils import get_current_timestamp
 
 # Local imports
 import logging
+import os  # For environment variables (PC name)
+from pathlib import Path  # Modern path handling
+
 from exceptions import SessionLockedError, StaleLockError
+from shared.atomic_write import atomic_write_json
+from shared.metadata_utils import get_current_timestamp
 
 # Initialize module-level logger
 logger = logging.getLogger(__name__)
@@ -64,8 +63,8 @@ class SessionManager:
         client_id: str,
         profile_manager,
         lock_manager,
-        worker_id: Optional[str] = None,
-        worker_name: Optional[str] = None
+        worker_id: str | None = None,
+        worker_name: str | None = None
     ):
         """
         Initialize SessionManager for a specific client.
@@ -90,7 +89,7 @@ class SessionManager:
 
         logger.info(f"SessionManager initialized for client {client_id} (Worker: {worker_name})")
 
-    def start_session(self, packing_list_path: str, restore_dir: str = None) -> str:
+    def start_session(self, packing_list_path: str, restore_dir: str | None = None) -> str:
         """
         Start a new packing session or restore a crashed session.
 
@@ -189,7 +188,7 @@ class SessionManager:
                         # Raise StaleLockError - UI will offer user option to force-release
                         # User can decide: "It's been 10 minutes, that PC probably crashed, I'll take over"
                         raise StaleLockError(
-                            f"Session has stale lock",
+                            "Session has stale lock",
                             lock_info=lock_info,
                             stale_minutes=stale_minutes
                         )
@@ -202,7 +201,7 @@ class SessionManager:
                         # Raise SessionLockedError - UI will show "User X on PC Y is working on this"
                         # User must wait or choose a different session
                         raise SessionLockedError(
-                            f"Session is locked by another process",
+                            "Session is locked by another process",
                             lock_info=lock_info
                         )
 
@@ -276,10 +275,10 @@ class SessionManager:
         try:
             atomic_write_json(info_path, session_info, indent=2)
             logger.debug(f"Created session info file: {info_path}")
-        except Exception as e:
+        except Exception:
             # Non-critical failure - session can still function
             # But recovery after crash will be harder without this file
-            logger.error(f"Failed to create session info file: {e}", exc_info=True)
+            logger.exception("Failed to create session info file")
 
         # === START HEARTBEAT MECHANISM ===
         # Start periodic timer that updates lock file every 60 seconds
@@ -350,7 +349,7 @@ class SessionManager:
         """
         return self.session_active
 
-    def get_output_dir(self) -> Optional[str]:
+    def get_output_dir(self) -> str | None:
         """
         Get the output directory for the current session.
 
@@ -359,7 +358,7 @@ class SessionManager:
         """
         return str(self.output_dir) if self.output_dir else None
 
-    def get_barcodes_dir(self) -> Optional[str]:
+    def get_barcodes_dir(self) -> str | None:
         """
         Get the barcodes subdirectory for the current session.
 
@@ -372,7 +371,7 @@ class SessionManager:
         barcodes_dir = self.output_dir / "barcodes"
         return str(barcodes_dir)
 
-    def get_session_info(self) -> Optional[dict]:
+    def get_session_info(self) -> dict | None:
         """
         Get session information from session_info.json.
 
@@ -390,8 +389,8 @@ class SessionManager:
         try:
             with open(info_path, 'r', encoding='utf-8') as f:
                 return json.load(f)
-        except Exception as e:
-            logger.error(f"Error reading session info: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Error reading session info")
             return None
 
     def _start_heartbeat(self):
@@ -451,10 +450,10 @@ class SessionManager:
             # PySide6 not available (e.g., running in test environment without Qt)
             # Non-fatal: session will work, but other PCs won't be able to detect crashes
             logger.warning("PySide6 not available, heartbeat disabled")
-        except Exception as e:
+        except Exception:
             # Unexpected error starting timer
             # Log but don't crash - session can still function without heartbeat
-            logger.error(f"Failed to start heartbeat timer: {e}", exc_info=True)
+            logger.exception("Failed to start heartbeat timer")
 
     def _stop_heartbeat(self):
         """
@@ -477,10 +476,10 @@ class SessionManager:
                 self.heartbeat_timer = None
 
                 logger.info("Heartbeat timer stopped")
-            except Exception as e:
+            except Exception:
                 # Non-critical failure - log and continue
                 # Timer will be garbage collected anyway when session ends
-                logger.error(f"Failed to stop heartbeat timer: {e}", exc_info=True)
+                logger.exception("Failed to stop heartbeat timer")
 
     def _update_heartbeat(self):
         """
@@ -521,10 +520,10 @@ class SessionManager:
                 logger.warning(f"Heartbeat update failed for session {self.session_id}")
                 # Note: We don't raise exception - session should continue working
 
-        except Exception as e:
+        except Exception:
             # Unexpected error during heartbeat update
             # Log but don't crash - this is a background operation
-            logger.error(f"Error updating heartbeat: {e}", exc_info=True)
+            logger.exception("Error updating heartbeat")
 
     def load_packing_list(self, session_path: str, packing_list_name: str) -> dict:
         """
@@ -571,8 +570,7 @@ class SessionManager:
 
         # 3. Remove .json extension if present (for flexibility)
         clean_name = packing_list_name
-        if clean_name.endswith('.json'):
-            clean_name = clean_name[:-5]
+        clean_name = clean_name.removesuffix('.json')
 
         # 4. Try to find the file with .json extension
         packing_list_file = packing_lists_dir / f"{clean_name}.json"
@@ -591,7 +589,7 @@ class SessionManager:
                 data = json.load(f)
         except json.JSONDecodeError as e:
             error_msg = f"Invalid JSON in packing list {packing_list_file}: {e}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise
 
         # 7. Validate that 'orders' key exists
@@ -665,7 +663,7 @@ class SessionManager:
 
         # 5. Log directory creation
         logger.info(f"Created packing work directory: {work_dir}")
-        logger.debug(f"Subdirectories: barcodes/, reports/")
+        logger.debug("Subdirectories: barcodes/, reports/")
 
         # 6. Return work directory path
         return work_dir

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -27,7 +27,7 @@ import logging
 import os  # For environment variables (PC name)
 from pathlib import Path  # Modern path handling
 
-from exceptions import SessionLockedError, StaleLockError
+from exceptions import SessionAlreadyActiveError, SessionLockedError, StaleLockError
 from shared.atomic_write import atomic_write_json
 from shared.metadata_utils import get_current_timestamp
 
@@ -129,7 +129,7 @@ class SessionManager:
             The session ID (directory name, e.g., "2025-11-03_14-30-45")
 
         Raises:
-            Exception: If a session is already active (call end_session() first)
+            SessionAlreadyActiveError: If a session is already active (call end_session() first)
             SessionLockedError: If session is actively locked by another process
                                (lock_info contains: locked_by, user_name, lock_time)
             StaleLockError: If session has a stale lock (process crashed/not responding)
@@ -140,7 +140,7 @@ class SessionManager:
         # This prevents confusion and ensures proper lock management
         if self.session_active:
             logger.error("Attempted to start session while one is already active")
-            raise Exception("A session is already active. Please end the current session first.")
+            raise SessionAlreadyActiveError("A session is already active. Please end the current session first.")
 
         logger.info(f"Starting session for client {self.client_id}")
 

--- a/src/session_registry_manager.py
+++ b/src/session_registry_manager.py
@@ -25,12 +25,11 @@ Design notes:
 """
 
 import json
+import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
 
-import logging
 from shared.atomic_write import atomic_write_json
 from shared.metadata_utils import get_current_timestamp, parse_timestamp
 
@@ -127,10 +126,10 @@ class SessionRegistryManager:
         try:
             atomic_write_json(path, registry, indent=2, ensure_ascii=False)
             return True
-        except Exception as e:
-            logger.error(
-                f"Failed to write registry for client {client_id} after 3 attempts: {e}"
-            , exc_info=True)
+        except Exception:
+            logger.exception(
+                f"Failed to write registry for client {client_id} after 3 attempts"
+            )
             return False
 
     def registry_exists(self, client_id: str) -> bool:
@@ -159,9 +158,9 @@ class SessionRegistryManager:
         try:
             registry = self.build_from_scan(client_id)
             return self.write_registry(client_id, registry)
-        except Exception as e:
-            logger.error(
-                f"Failed to build registry for client {client_id}: {e}", exc_info=True
+        except Exception:
+            logger.exception(
+                f"Failed to build registry for client {client_id}"
             )
             return False
 
@@ -193,8 +192,8 @@ class SessionRegistryManager:
                 session_count += 1
                 self._scan_session_dir(registry, client_id, session_id, session_dir)
 
-        except Exception as e:
-            logger.error(f"Error scanning {client_dir}: {e}", exc_info=True)
+        except Exception:
+            logger.exception(f"Error scanning {client_dir}")
 
         logger.info(
             f"Registry scan for client {client_id} complete: "
@@ -280,8 +279,8 @@ class SessionRegistryManager:
                 with open(info_file, "r", encoding="utf-8") as f:
                     session_info = json.load(f)
                 pc_name = session_info.get("pc_name", pc_name)
-            except Exception:
-                pass
+            except Exception as info_exc:
+                logger.debug(f"Could not read pc_name from {info_file}: {info_exc}")
 
         if summary_file.exists():
             try:
@@ -390,8 +389,8 @@ class SessionRegistryManager:
         client_id: str,
         session_id: str,
         packing_list_name: str,
-        worker_id: Optional[str],
-        worker_name: Optional[str],
+        worker_id: str | None,
+        worker_name: str | None,
         pc_name: str,
         total_orders: int,
         total_items: int,
@@ -618,7 +617,7 @@ class SessionRegistryManager:
         return stored or "incomplete"
 
     @staticmethod
-    def _get_lock_heartbeat_age(lock_file: Path) -> Optional[float]:
+    def _get_lock_heartbeat_age(lock_file: Path) -> float | None:
         """
         Read .session.lock and return seconds since last heartbeat.
         Returns None if the file cannot be read or parsed.
@@ -702,8 +701,8 @@ class SessionRegistryManager:
                     new_count += 1
                     changed = True
 
-        except Exception as e:
-            logger.error(f"Error scanning for new available lists: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Error scanning for new available lists")
 
         if changed:
             self.write_registry(client_id, registry)

--- a/src/session_selector.py
+++ b/src/session_selector.py
@@ -12,19 +12,28 @@ Integration with Shopify Tool (Phase 1.3.2):
 - Returns selected session path for loading
 """
 
-from pathlib import Path
-from datetime import datetime
-from typing import Optional, List, Dict
-
-from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QComboBox,
-    QListWidget, QListWidgetItem, QPushButton, QDateEdit,
-    QCheckBox, QMessageBox, QGroupBox, QApplication
-)
-from PySide6.QtGui import QPalette
-from PySide6.QtCore import Qt, QDate, QThread, Signal
-
 import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from PySide6.QtCore import QDate, Qt, QThread, Signal
+from PySide6.QtGui import QPalette
+from PySide6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QComboBox,
+    QDateEdit,
+    QDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+)
+
 from json_cache import get_cached_json
 from session_registry_manager import SessionRegistryManager
 from shared.metadata_utils import parse_timestamp
@@ -53,7 +62,7 @@ class SessionScanWorker(QThread):
             sessions = self._scan_fn(self._client_id)
             self.scan_complete.emit(sessions)
         except Exception as exc:
-            logger.error(f"SessionScanWorker failed: {exc}", exc_info=True)
+            logger.exception("SessionScanWorker failed")
             self.scan_failed.emit(str(exc))
 
 
@@ -90,8 +99,8 @@ class SessionSelectorDialog(QDialog):
         self.selected_session_path = None
         self.selected_session_data = None
         self.selected_packing_list_path = None  # NEW: Selected packing list JSON path
-        self._all_sessions: Optional[List[Dict]] = None  # Cached raw session list
-        self._scan_worker: Optional[SessionScanWorker] = None
+        self._all_sessions: list[dict] | None = None  # Cached raw session list
+        self._scan_worker: SessionScanWorker | None = None
 
         self.setWindowTitle("Select Shopify Session to Pack")
         self.setMinimumWidth(700)
@@ -254,7 +263,7 @@ class SessionSelectorDialog(QDialog):
             logger.info(f"Loaded {len(clients)} clients")
 
         except Exception as e:
-            logger.error(f"Error loading clients: {e}", exc_info=True)
+            logger.exception("Error loading clients")
             QMessageBox.warning(self, "Error", f"Failed to load clients:\n\n{e}")
 
         finally:
@@ -287,7 +296,7 @@ class SessionSelectorDialog(QDialog):
                     display_name = f"{config.get('client_name', self.pre_selected_client)} ({self.pre_selected_client})"
                 else:
                     display_name = self.pre_selected_client
-            except:
+            except Exception:
                 display_name = self.pre_selected_client
 
             self.client_label = QLabel(f"Client: {display_name}")
@@ -356,7 +365,7 @@ class SessionSelectorDialog(QDialog):
         self._scan_worker.scan_failed.connect(self._on_scan_failed)
         self._scan_worker.start()
 
-    def _on_sessions_loaded(self, sessions: List[Dict]):
+    def _on_sessions_loaded(self, sessions: list[dict]):
         """Called on the UI thread when background session scan finishes."""
         self._all_sessions = sessions
         self._apply_filters_and_populate()
@@ -450,7 +459,7 @@ class SessionSelectorDialog(QDialog):
             # No cached data yet — trigger a full background scan
             self._refresh_sessions_for_client(client_id)
 
-    def _scan_shopify_sessions(self, client_id: str) -> List[Dict]:
+    def _scan_shopify_sessions(self, client_id: str) -> list[dict]:
         """
         Scan for Shopify sessions in Sessions/CLIENT_{ID}/ directory.
 
@@ -478,8 +487,8 @@ class SessionSelectorDialog(QDialog):
             registry_manager = SessionRegistryManager(self.profile_manager)
             registry_manager.ensure_registry(client_id)
             registry_manager.refresh_available_lists(client_id)
-        except Exception as e:
-            logger.error(f"Error refreshing packing-list registry: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Error refreshing packing-list registry")
 
         sessions = []
 
@@ -491,7 +500,7 @@ class SessionSelectorDialog(QDialog):
                 session_info = {
                     'name': session_dir.name,
                     'path': session_dir,
-                    'modified': datetime.fromtimestamp(session_dir.stat().st_mtime),
+                    'modified': datetime.fromtimestamp(session_dir.stat().st_mtime).astimezone(),
                     'has_shopify_data': False,
                     'orders_count': 0
                 }
@@ -518,11 +527,11 @@ class SessionSelectorDialog(QDialog):
 
             return sessions
 
-        except Exception as e:
-            logger.error(f"Error scanning sessions: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Error scanning sessions")
             return []
 
-    def _filter_by_date(self, sessions: List[Dict]) -> List[Dict]:
+    def _filter_by_date(self, sessions: list[dict]) -> list[dict]:
         """
         Filter sessions by date range.
 
@@ -543,7 +552,7 @@ class SessionSelectorDialog(QDialog):
 
         return filtered
 
-    def _scan_packing_lists(self, client_id: str, session_path: Path) -> List[Dict]:
+    def _scan_packing_lists(self, client_id: str, session_path: Path) -> list[dict]:
         """
         List packing lists for a session from registry_index.json instead of
         re-scanning session/packing_lists/*.json on the file server.
@@ -558,8 +567,8 @@ class SessionSelectorDialog(QDialog):
         try:
             registry_manager = SessionRegistryManager(self.profile_manager)
             entries = registry_manager.get_all_entries(client_id)
-        except Exception as e:
-            logger.error(f"Error reading registry for packing lists: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Error reading registry for packing lists")
             return []
 
         session_path_str = str(session_path)
@@ -576,7 +585,7 @@ class SessionSelectorDialog(QDialog):
                 'name': name,
                 'filename': f"{name}.json",
                 'path': session_path / "packing_lists" / f"{name}.json",
-                'modified': parse_timestamp(timestamp) or datetime.min,
+                'modified': parse_timestamp(timestamp) or datetime.min.replace(tzinfo=timezone.utc),
                 'orders_count': entry.get('total_orders', 0),
                 'courier': entry.get('courier') or None,
                 'list_name': name,
@@ -611,7 +620,7 @@ class SessionSelectorDialog(QDialog):
 
         if session.get('has_shopify_data'):
             info_text += f"<b>Orders:</b> {session.get('orders_count', 0)}<br>"
-            info_text += f"<b>Type:</b> Shopify Session<br>"
+            info_text += "<b>Type:</b> Shopify Session<br>"
 
             # Show path to analysis data
             analysis_path = session['path'] / "analysis" / "analysis_data.json"
@@ -739,7 +748,7 @@ class SessionSelectorDialog(QDialog):
 
         self.accept()
 
-    def get_selected_session(self) -> Optional[Path]:
+    def get_selected_session(self) -> Path | None:
         """
         Get selected session path.
 
@@ -748,7 +757,7 @@ class SessionSelectorDialog(QDialog):
         """
         return self.selected_session_path
 
-    def get_session_data(self) -> Optional[Dict]:
+    def get_session_data(self) -> dict | None:
         """
         Get selected session's analysis data.
 
@@ -757,7 +766,7 @@ class SessionSelectorDialog(QDialog):
         """
         return self.selected_session_data
 
-    def get_selected_packing_list(self) -> Optional[Path]:
+    def get_selected_packing_list(self) -> Path | None:
         """
         Get selected packing list path.
 

--- a/src/sku_mapping_dialog.py
+++ b/src/sku_mapping_dialog.py
@@ -5,14 +5,21 @@ Phase 1.3: Redesigned to use ProfileManager for centralized storage on file serv
 All changes are synchronized across all PCs accessing the same client.
 """
 
-from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QTableWidget, QTableWidgetItem,
-    QPushButton, QMessageBox, QInputDialog, QHeaderView, QAbstractItemView,
-    QLabel
-)
-from typing import Dict
-
 import logging
+
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QHBoxLayout,
+    QHeaderView,
+    QInputDialog,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +57,7 @@ class SKUMappingDialog(QDialog):
             self.current_map = self.profile_manager.load_sku_mapping(client_id).copy()
             logger.info(f"Loaded {len(self.current_map)} SKU mappings for client {client_id}")
         except Exception as e:
-            logger.error(f"Failed to load SKU mappings: {e}", exc_info=True)
+            logger.exception("Failed to load SKU mappings")
             self.current_map = {}
             QMessageBox.warning(
                 self,
@@ -250,13 +257,12 @@ class SKUMappingDialog(QDialog):
             QMessageBox.StandardButton.No
         )
 
-        if reply == QMessageBox.StandardButton.Yes:
-            if barcode in self.current_map:
-                del self.current_map[barcode]
-                self._populate_table()
-                self.status_label.setText(f"{len(self.current_map)} mapping(s) - Not saved yet")
+        if reply == QMessageBox.StandardButton.Yes and barcode in self.current_map:
+            del self.current_map[barcode]
+            self._populate_table()
+            self.status_label.setText(f"{len(self.current_map)} mapping(s) - Not saved yet")
 
-                logger.info(f"Deleted SKU mapping: {barcode}")
+            logger.info(f"Deleted SKU mapping: {barcode}")
 
     def _reload_from_server(self):
         """Reload mappings from file server, discarding unsaved changes."""
@@ -281,7 +287,7 @@ class SKUMappingDialog(QDialog):
             logger.info(f"Reloaded {len(self.current_map)} SKU mappings from server")
 
         except Exception as e:
-            logger.error(f"Failed to reload SKU mappings: {e}", exc_info=True)
+            logger.exception("Failed to reload SKU mappings")
             QMessageBox.critical(
                 self,
                 "Reload Error",
@@ -314,7 +320,7 @@ class SKUMappingDialog(QDialog):
                 )
 
         except Exception as e:
-            logger.error(f"Error saving SKU mappings: {e}", exc_info=True)
+            logger.exception("Error saving SKU mappings")
             QMessageBox.critical(
                 self,
                 "Save Error",
@@ -322,7 +328,7 @@ class SKUMappingDialog(QDialog):
                 f"Your changes were NOT saved."
             )
 
-    def get_mappings(self) -> Dict[str, str]:
+    def get_mappings(self) -> dict[str, str]:
         """
         Returns the current mappings.
 

--- a/src/theme.py
+++ b/src/theme.py
@@ -8,7 +8,8 @@ every call site) so packing-tool/src/main.py's existing
 from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import QApplication
 
-from shared.theme import apply_theme as _apply_theme, THEME_DARK, THEME_LIGHT
+from shared.theme import THEME_DARK, THEME_LIGHT
+from shared.theme import apply_theme as _apply_theme
 
 __all__ = ["THEME_DARK", "THEME_LIGHT", "apply_theme", "load_saved_theme", "toggle_theme"]
 

--- a/src/worker_manager.py
+++ b/src/worker_manager.py
@@ -7,10 +7,8 @@ Simple trust-based system without authentication.
 
 import json
 import logging
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import List, Optional, Dict
-from datetime import datetime
-from dataclasses import dataclass, asdict
 
 from shared.atomic_write import atomic_write_json
 
@@ -36,8 +34,8 @@ class WorkerProfile:
     avg_orders_per_session: float = 0.0    # Average orders per session
 
     # Activity tracking
-    last_active: Optional[str] = None      # ISO timestamp with timezone
-    last_session_id: Optional[str] = None  # Last completed session
+    last_active: str | None = None      # ISO timestamp with timezone
+    last_session_id: str | None = None  # Last completed session
 
     # Metadata
     version: str = "1.3.0"
@@ -113,11 +111,11 @@ class WorkerManager:
         try:
             self.workers_dir.mkdir(parents=True, exist_ok=True)
             logger.debug(f"Workers directory ready: {self.workers_dir}")
-        except Exception as e:
-            logger.error(f"Failed to create Workers directory: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to create Workers directory")
             raise
 
-    def _load_workers_registry(self) -> Dict[str, list]:
+    def _load_workers_registry(self) -> dict[str, list]:
         """Load workers.json registry
 
         Returns:
@@ -134,19 +132,19 @@ class WorkerManager:
             logger.debug(f"Loaded {len(data.get('workers', []))} workers from registry")
             return data
 
-        except json.JSONDecodeError as e:
-            logger.error(f"Corrupted workers.json: {e}", exc_info=True)
+        except json.JSONDecodeError:
+            logger.exception("Corrupted workers.json")
             # Backup corrupted file
             backup_path = self.workers_file.with_suffix('.json.backup')
             self.workers_file.rename(backup_path)
             logger.warning(f"Corrupted file backed up to: {backup_path}")
             return {"workers": []}
 
-        except Exception as e:
-            logger.error(f"Failed to load workers registry: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to load workers registry")
             raise
 
-    def _save_workers_registry(self, data: Dict[str, list]):
+    def _save_workers_registry(self, data: dict[str, list]):
         """Save workers.json registry with version
 
         Args:
@@ -160,11 +158,11 @@ class WorkerManager:
 
             logger.debug(f"Saved {len(data['workers'])} workers to registry (v1.3.0)")
 
-        except Exception as e:
-            logger.error(f"Failed to save workers registry: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to save workers registry")
             raise
 
-    def get_all_workers(self) -> List[WorkerProfile]:
+    def get_all_workers(self) -> list[WorkerProfile]:
         """Get all worker profiles
 
         Returns:
@@ -176,7 +174,7 @@ class WorkerManager:
         logger.info(f"Retrieved {len(workers)} worker profiles")
         return workers
 
-    def get_worker(self, worker_id: str) -> Optional[WorkerProfile]:
+    def get_worker(self, worker_id: str) -> WorkerProfile | None:
         """Get specific worker profile
 
         Args:
@@ -246,7 +244,7 @@ class WorkerManager:
         logger.info(f"Created worker: {worker_id} ({name})")
         return worker
 
-    def _generate_worker_id(self, existing_workers: List[WorkerProfile]) -> str:
+    def _generate_worker_id(self, existing_workers: list[WorkerProfile]) -> str:
         """Generate unique worker ID
 
         Args:
@@ -276,7 +274,7 @@ class WorkerManager:
         orders: int = 0,
         items: int = 0,
         duration_seconds: int = 0,
-        session_id: str = None
+        session_id: str | None = None
     ):
         """Update worker statistics (incremental)
 

--- a/src/worker_selection_dialog.py
+++ b/src/worker_selection_dialog.py
@@ -6,12 +6,23 @@ No authentication - trust-based system.
 """
 
 import logging
-from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QLabel,
-    QScrollArea, QWidget, QFrame, QMessageBox, QInputDialog, QApplication
-)
+
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QFont
+from PySide6.QtWidgets import (
+    QApplication,
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QInputDialog,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
 from worker_manager import WorkerManager, WorkerProfile
 
 logger = logging.getLogger(__name__)
@@ -238,11 +249,11 @@ class WorkerSelectionDialog(QDialog):
             self.cards_layout.addStretch()
 
         except Exception as e:
-            logger.error(f"Failed to load workers: {e}", exc_info=True)
+            logger.exception("Failed to load workers")
             QMessageBox.critical(
                 self,
                 "Error",
-                f"Failed to load worker profiles:\n{str(e)}"
+                f"Failed to load worker profiles:\n{e!s}"
             )
 
     def _on_worker_selected(self, worker_id: str):
@@ -303,11 +314,11 @@ class WorkerSelectionDialog(QDialog):
                 str(e)
             )
         except Exception as e:
-            logger.error(f"Failed to create worker: {e}", exc_info=True)
+            logger.exception("Failed to create worker")
             QMessageBox.critical(
                 self,
                 "Error",
-                f"Failed to create worker:\n{str(e)}"
+                f"Failed to create worker:\n{e!s}"
             )
 
     def get_selected_worker_id(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,11 +10,11 @@ Design notes:
   _reset_root_logger fixture is autouse there; this file doesn't need
   its own equivalent since no test here asserts on handler counts.
 """
+import configparser
+import json
 import logging
 import os
 import sys
-import json
-import configparser
 from pathlib import Path
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -24,10 +24,10 @@ sys.path.insert(0, str(ROOT / "src"))
 sys.path.insert(0, str(ROOT))
 
 import pytest
-
 from PySide6.QtWidgets import QApplication
-from profile_manager import ProfileManager
+
 from packer_logic import PackerLogic
+from profile_manager import ProfileManager
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -188,7 +188,7 @@ def loaded_logic(packer_logic_factory, session_factory):
             [{"sku": "SKU-CCC", "quantity": 1, "product_name": "Widget C"}],
         ),
     ]
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
     logic = packer_logic_factory("M", work_dir)
     logic.load_packing_list_json(list_path)
     return logic

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -22,7 +22,6 @@ import pytest
 from shared.atomic_write import atomic_write_json
 from shared.stats_manager import StatsManager, StatsManagerError
 
-
 # ---------------------------------------------------------------------------
 # shared.atomic_write.atomic_write_json — the reference implementation
 # ---------------------------------------------------------------------------

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -12,7 +12,7 @@ import time
 
 import pytest
 
-from shared.logger import setup_logging, _sweep_old_logs, _active_handlers
+from shared.logger import _active_handlers, _sweep_old_logs, setup_logging
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -7,10 +7,10 @@ from datetime import datetime
 import pytest
 
 from shared.metadata_utils import (
-    get_current_timestamp,
-    parse_timestamp,
     calculate_duration,
+    get_current_timestamp,
     load_session_summary,
+    parse_timestamp,
 )
 
 

--- a/tests/test_packer_logic_dataframe_integrity.py
+++ b/tests/test_packer_logic_dataframe_integrity.py
@@ -11,9 +11,6 @@ import json
 
 import pytest
 
-from packer_logic import PackerLogic
-
-
 # ---------------------------------------------------------------------------
 # load_packing_list_json — exact field fidelity
 # ---------------------------------------------------------------------------
@@ -22,7 +19,7 @@ def test_loaded_items_preserve_original_sku_and_product_name_verbatim(packer_log
     orders = [("ORD-1", "DHL", [
         {"sku": "  SKU-123 (Special!) ", "quantity": 3, "product_name": "Крем для обличчя — 50 мл"},
     ])]
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
     logic = packer_logic_factory("M", work_dir)
     logic.load_packing_list_json(list_path)
 
@@ -35,7 +32,7 @@ def test_loaded_items_preserve_original_sku_and_product_name_verbatim(packer_log
 
 
 def test_loaded_order_carries_extra_metadata_fields_unmodified(packer_logic_factory, session_factory):
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=[])
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=[])
     packing_list = {
         "list_name": "DHL_Orders",
         "orders": [{
@@ -61,7 +58,7 @@ def test_loaded_order_carries_extra_metadata_fields_unmodified(packer_logic_fact
 
 
 def test_missing_order_number_raises_instead_of_silently_dropping(packer_logic_factory, session_factory):
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=[])
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=[])
     packing_list = {
         "orders": [{"courier": "DHL", "items": [{"sku": "SKU-1", "quantity": 1}]}]  # no order_number
     }
@@ -73,7 +70,7 @@ def test_missing_order_number_raises_instead_of_silently_dropping(packer_logic_f
 
 
 def test_missing_courier_raises_for_packing_list(packer_logic_factory, session_factory):
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=[])
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=[])
     packing_list = {
         "orders": [{"order_number": "ORD-1", "items": [{"sku": "SKU-1", "quantity": 1}]}]  # no courier
     }
@@ -85,7 +82,7 @@ def test_missing_courier_raises_for_packing_list(packer_logic_factory, session_f
 
 
 def test_order_with_no_items_is_skipped_not_crashed(packer_logic_factory, session_factory):
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=[])
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=[])
     packing_list = {
         "orders": [
             {"order_number": "ORD-EMPTY", "courier": "DHL", "items": []},
@@ -102,7 +99,7 @@ def test_order_with_no_items_is_skipped_not_crashed(packer_logic_factory, sessio
 
 
 def test_missing_packing_list_file_raises_value_error(packer_logic_factory, session_factory):
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=[])
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=[])
     missing_path = list_path.parent / "does_not_exist.json"
     logic = packer_logic_factory("M", work_dir)
     with pytest.raises(ValueError):
@@ -110,7 +107,7 @@ def test_missing_packing_list_file_raises_value_error(packer_logic_factory, sess
 
 
 def test_invalid_json_raises_value_error_not_a_crash(packer_logic_factory, session_factory):
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=[])
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=[])
     list_path.write_text("{not valid json", encoding="utf-8")
     logic = packer_logic_factory("M", work_dir)
     with pytest.raises(ValueError):
@@ -131,7 +128,7 @@ def test_garbage_quantity_silently_becomes_one_instead_of_erroring(loaded_logic,
     of unnoticed order-content drift target #1 cares about.
     """
     orders = [("ORD-1", "DHL", [{"sku": "SKU-1", "quantity": "N/A", "product_name": "Widget"}])]
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
     logic = packer_logic_factory("M", work_dir)
     logic.load_packing_list_json(list_path)
 
@@ -141,7 +138,7 @@ def test_garbage_quantity_silently_becomes_one_instead_of_erroring(loaded_logic,
 
 def test_decimal_quantity_string_is_coerced_correctly(packer_logic_factory, session_factory):
     orders = [("ORD-1", "DHL", [{"sku": "SKU-1", "quantity": "3.0", "product_name": "Widget"}])]
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
     logic = packer_logic_factory("M", work_dir)
     logic.load_packing_list_json(list_path)
     logic.start_order_packing("ORD-1")
@@ -162,7 +159,7 @@ def test_duplicate_order_number_silently_merges_items_and_keeps_last_metadata(pa
     show one merged order with items from both, under the second order's
     address/notes.
     """
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=[])
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=[])
     packing_list = {
         "orders": [
             {

--- a/tests/test_packer_logic_scanning.py
+++ b/tests/test_packer_logic_scanning.py
@@ -68,7 +68,7 @@ def test_scan_completes_order_only_when_every_item_done(loaded_logic):
     loaded_logic.start_order_packing("ORDER-001")
     loaded_logic.process_sku_scan("SKU-AAA")
     loaded_logic.process_sku_scan("SKU-AAA")  # SKU-AAA fully packed, SKU-BBB still pending
-    result, status = loaded_logic.process_sku_scan("SKU-BBB")
+    _result, status = loaded_logic.process_sku_scan("SKU-BBB")
     assert status == "ORDER_COMPLETE"
     assert loaded_logic.current_order_number == "ORDER-001"  # not auto-cleared; caller's job
     assert "ORDER-001" in loaded_logic.session_packing_state["completed_orders"]
@@ -87,7 +87,7 @@ def test_scan_wrong_sku_returns_sku_not_found_and_is_recorded(loaded_logic):
 def test_scan_beyond_required_quantity_is_extra_not_silently_accepted(loaded_logic):
     loaded_logic.start_order_packing("ORDER-002")  # SKU-CCC requires 1
     loaded_logic.process_sku_scan("SKU-CCC")
-    result, status = loaded_logic.process_sku_scan("SKU-CCC")  # second scan of a qty-1 item
+    _result, status = loaded_logic.process_sku_scan("SKU-CCC")  # second scan of a qty-1 item
     assert status == "SKU_EXTRA"
     assert loaded_logic.current_extra_items == {"skuccc": 1}
 
@@ -101,7 +101,7 @@ def test_sku_normalization_ignores_case_and_punctuation(loaded_logic):
 
 def test_sku_map_translates_barcode_to_internal_sku(packer_logic_factory, session_factory, profile_manager):
     orders = [("ORDER-001", "DHL", [{"sku": "INTERNAL-SKU-1", "quantity": 1, "product_name": "Widget"}])]
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
     profile_manager.create_client_profile("M", "Test Client")
     profile_manager.save_sku_mapping("M", {"7290018664100": "INTERNAL-SKU-1"})
 
@@ -135,7 +135,7 @@ def test_cancel_item_scan_at_zero_is_a_noop(loaded_logic):
 
 
 def test_cancel_item_scan_without_active_order(loaded_logic):
-    result, status = loaded_logic.cancel_item_scan(0)
+    _result, status = loaded_logic.cancel_item_scan(0)
     assert status == "NO_ACTIVE_ORDER"
 
 
@@ -151,7 +151,7 @@ def test_cancel_after_order_complete_is_rejected_because_current_order_is_cleare
 
     loaded_logic.clear_current_order()  # what the UI does right after ORDER_COMPLETE
 
-    result, status = loaded_logic.cancel_item_scan(0)
+    _result, status = loaded_logic.cancel_item_scan(0)
     assert status == "NO_ACTIVE_ORDER"
     # Order must not have been resurrected into in_progress
     assert "ORDER-002" not in loaded_logic.session_packing_state["in_progress"]
@@ -204,7 +204,7 @@ def test_force_confirm_on_partially_scanned_item_only_adds_remaining_record(load
 
 
 def test_force_confirm_without_active_order(loaded_logic):
-    result, status = loaded_logic.force_confirm_item(0)
+    _result, status = loaded_logic.force_confirm_item(0)
     assert status == "NO_ACTIVE_ORDER"
 
 
@@ -216,7 +216,7 @@ def test_extra_scan_on_a_not_yet_complete_order_does_not_finish_it(loaded_logic)
     loaded_logic.start_order_packing("ORDER-001")
     loaded_logic.process_sku_scan("SKU-AAA")
     loaded_logic.process_sku_scan("SKU-AAA")  # SKU-AAA done (2/2), SKU-BBB still pending
-    result, status = loaded_logic.process_sku_scan("SKU-AAA")  # over-scan SKU-AAA
+    _result, status = loaded_logic.process_sku_scan("SKU-AAA")  # over-scan SKU-AAA
     assert status == "SKU_EXTRA"
     assert "ORDER-001" not in loaded_logic.session_packing_state["completed_orders"]
 
@@ -230,14 +230,14 @@ def test_order_complete_with_extras_status_when_last_required_item_scanned(packe
         {"sku": "SKU-1", "quantity": 1, "product_name": "A"},
         {"sku": "SKU-2", "quantity": 1, "product_name": "B"},
     ])]
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
     logic = packer_logic_factory("M", work_dir)
     logic.load_packing_list_json(list_path)
 
     logic.start_order_packing("ORDER-X")
     logic.process_sku_scan("SKU-1")        # 1/1, order not complete yet (SKU-2 pending)
     logic.process_sku_scan("SKU-1")        # extra on SKU-1
-    result, status = logic.process_sku_scan("SKU-2")  # completes required qty for every item
+    _result, status = logic.process_sku_scan("SKU-2")  # completes required qty for every item
 
     assert status == "ORDER_COMPLETE_WITH_EXTRAS"
     assert "ORDER-X" not in logic.session_packing_state["completed_orders"]
@@ -253,7 +253,7 @@ def test_confirm_keep_extra_completes_order_once_all_extras_resolved(loaded_logi
     assert loaded_logic.current_extra_items == {"skuaaa": 1}
     assert "ORDER-001" not in loaded_logic.session_packing_state["completed_orders"]
 
-    result, status = loaded_logic.confirm_keep_extra("skuaaa")
+    _result, status = loaded_logic.confirm_keep_extra("skuaaa")
     assert status == "ORDER_NOW_COMPLETE"
     assert "ORDER-001" in loaded_logic.session_packing_state["completed_orders"]
     assert loaded_logic.current_extra_items == {}

--- a/tests/test_packer_logic_state_persistence.py
+++ b/tests/test_packer_logic_state_persistence.py
@@ -6,10 +6,10 @@ session. These tests exercise the *real* file writes (via AsyncStateWriter's
 background thread + the atomic temp-file-then-rename in
 PackerLogic._do_atomic_write), not a stubbed writer.
 """
-import json
 import copy
+import json
 
-from json_cache import get_cached_json, invalidate_json_cache
+from json_cache import get_cached_json
 
 
 def _read_state_file(work_dir):
@@ -65,7 +65,7 @@ def test_sku_ok_writes_land_after_flush(loaded_logic):
 
 def test_legacy_item_format_is_migrated_on_load(packer_logic_factory, session_factory):
     orders = [("ORDER-001", "DHL", [{"sku": "SKU-AAA", "quantity": 2, "product_name": "Widget"}])]
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
 
     legacy_state = {
         "in_progress": {
@@ -94,7 +94,7 @@ def test_malformed_order_state_is_skipped_without_crashing(packer_logic_factory,
         ("ORDER-BAD", "DHL", [{"sku": "SKU-2", "quantity": 1, "product_name": "B"}]),
         ("ORDER-BAD2", "DHL", [{"sku": "SKU-3", "quantity": 1, "product_name": "C"}]),
     ]
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
 
     corrupt_state = {
         "in_progress": {
@@ -117,7 +117,7 @@ def test_malformed_order_state_is_skipped_without_crashing(packer_logic_factory,
 
 def test_missing_state_file_starts_fresh(packer_logic_factory, session_factory):
     orders = [("ORDER-001", "DHL", [{"sku": "SKU-1", "quantity": 1, "product_name": "A"}])]
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
+    _session_dir, work_dir, _list_path = session_factory(client_id="M", orders=orders)
 
     logic = packer_logic_factory("M", work_dir)
     assert logic.session_packing_state == {
@@ -127,7 +127,7 @@ def test_missing_state_file_starts_fresh(packer_logic_factory, session_factory):
 
 def test_corrupted_json_state_file_starts_fresh_instead_of_crashing(packer_logic_factory, session_factory):
     orders = [("ORDER-001", "DHL", [{"sku": "SKU-1", "quantity": 1, "product_name": "A"}])]
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
+    _session_dir, work_dir, _list_path = session_factory(client_id="M", orders=orders)
     (work_dir / "packing_state.json").write_text("{not valid json", encoding="utf-8")
 
     logic = packer_logic_factory("M", work_dir)  # must not raise
@@ -151,7 +151,7 @@ def test_unresolved_extras_survive_a_restart(packer_logic_factory, session_facto
         {"sku": "SKU-1", "quantity": 1, "product_name": "A1"},
         {"sku": "SKU-2", "quantity": 1, "product_name": "A2"},
     ])]
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
 
     instance1 = packer_logic_factory("M", work_dir)
     instance1.load_packing_list_json(list_path)
@@ -172,7 +172,7 @@ def test_unresolved_extras_survive_a_restart(packer_logic_factory, session_facto
     # it clean, even though a real extra unit is still sitting unresolved in the box.
     instance2.load_packing_list_json(list_path)
     instance2.start_order_packing("ORDER-A")
-    result, status = instance2.process_sku_scan("SKU-2")  # the only remaining required item
+    _result, status = instance2.process_sku_scan("SKU-2")  # the only remaining required item
     assert status == "ORDER_COMPLETE_WITH_EXTRAS", (
         f"expected the pending extra to block clean completion, got {status!r}"
     )
@@ -188,7 +188,7 @@ def test_unresolved_extras_survive_a_restart(packer_logic_factory, session_facto
 
 def test_json_cache_is_not_mutated_by_in_memory_migration(packer_logic_factory, session_factory):
     orders = [("ORDER-001", "DHL", [{"sku": "SKU-AAA", "quantity": 2, "product_name": "Widget"}])]
-    session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
+    _session_dir, work_dir, list_path = session_factory(client_id="M", orders=orders)
 
     legacy_state = {
         "in_progress": {"ORDER-001": [{"sku": "SKU-AAA", "packed": 0}]},  # no 'required'/'row'
@@ -200,7 +200,7 @@ def test_json_cache_is_not_mutated_by_in_memory_migration(packer_logic_factory, 
     disk_snapshot_before = copy.deepcopy(json.loads(state_path.read_text(encoding="utf-8")))
 
     # Warm the cache the way Session Browser would, before packing starts.
-    pre_read = get_cached_json(state_path, default=None)
+    get_cached_json(state_path, default=None)
 
     logic = packer_logic_factory("M", work_dir)  # triggers the in-place migration
     logic.load_packing_list_json(list_path)

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -7,7 +7,6 @@ import pytest
 
 from profile_manager import ProfileManager, ValidationError
 
-
 # ---------------------------------------------------------------------------
 # validate_client_id
 # ---------------------------------------------------------------------------

--- a/tests/test_session_lock_manager.py
+++ b/tests/test_session_lock_manager.py
@@ -44,7 +44,7 @@ def _write_foreign_lock(session_dir, *, hostname="OTHER-PC", process_id=99999, h
 # ---------------------------------------------------------------------------
 
 def test_acquire_lock_creates_lock_file(lock_manager, session_dir):
-    success, error, info = lock_manager.acquire_lock("M", session_dir, worker_id="w1", worker_name="Worker One")
+    success, error, _info = lock_manager.acquire_lock("M", session_dir, worker_id="w1", worker_name="Worker One")
     assert success is True
     assert error is None
     lock_path = session_dir / SessionLockManager.LOCK_FILENAME
@@ -60,7 +60,7 @@ def test_reacquiring_own_lock_succeeds_and_updates_heartbeat(lock_manager, sessi
     lock_path = session_dir / SessionLockManager.LOCK_FILENAME
     original_heartbeat = json.loads(lock_path.read_text(encoding="utf-8"))["heartbeat"]
 
-    success, error, info = lock_manager.acquire_lock("M", session_dir)
+    success, error, _info = lock_manager.acquire_lock("M", session_dir)
     assert success is True
     assert error is None
 
@@ -167,6 +167,6 @@ def test_same_pc_different_process_is_treated_as_a_foreign_lock_until_stale(lock
     monkeypatch.setattr(lock_manager, "hostname", "MY-PC")
     _write_foreign_lock(session_dir, hostname="MY-PC", process_id=lock_manager.process_id + 1, heartbeat_age_seconds=5)
 
-    success, error, info = lock_manager.acquire_lock("M", session_dir)
+    success, _error, info = lock_manager.acquire_lock("M", session_dir)
     assert success is False  # blocked from resuming its own crashed session on the same PC
     assert info["locked_by"] == "MY-PC"

--- a/tests/test_session_lock_manager.py
+++ b/tests/test_session_lock_manager.py
@@ -64,6 +64,9 @@ def test_reacquiring_own_lock_succeeds_and_updates_heartbeat(lock_manager, sessi
     assert success is True
     assert error is None
 
+    new_heartbeat = json.loads(lock_path.read_text(encoding="utf-8"))["heartbeat"]
+    assert new_heartbeat != original_heartbeat
+
 
 def test_acquire_lock_fails_when_actively_held_by_another_pc(lock_manager, session_dir):
     _write_foreign_lock(session_dir, hostname="OTHER-PC", heartbeat_age_seconds=5)  # fresh heartbeat

--- a/tests/test_session_selector_packing_lists.py
+++ b/tests/test_session_selector_packing_lists.py
@@ -6,6 +6,7 @@ _scan_shopify_sessions() registry refresh call.
 import json
 
 from conftest import make_packing_list
+
 from session_registry_manager import SessionRegistryManager
 from session_selector import SessionSelectorDialog
 

--- a/tests/test_stats_manager.py
+++ b/tests/test_stats_manager.py
@@ -8,8 +8,9 @@ surface end to end.
 """
 from datetime import datetime, timedelta
 
-from shared.stats_manager import StatsManager, FileLockError as StatsFileLockError
 from shared.file_lock import FileLockError as SharedFileLockError
+from shared.stats_manager import FileLockError as StatsFileLockError
+from shared.stats_manager import StatsManager
 
 
 def test_default_stats_version_is_the_unified_value(tmp_path):
@@ -133,8 +134,8 @@ def test_get_label_print_history_accepts_naive_dates_from_the_gui(tmp_path):
     manager = StatsManager(str(tmp_path))
     manager.record_label_print(client_id="M", sku="SKU-1", copies=1)
 
-    naive_start = datetime.now() - timedelta(days=1)
-    naive_end = datetime.now() + timedelta(days=1)
+    naive_start = datetime.now() - timedelta(days=1)  # noqa: DTZ005 -- naive on purpose, see docstring
+    naive_end = datetime.now() + timedelta(days=1)  # noqa: DTZ005 -- naive on purpose, see docstring
 
     history = manager.get_label_print_history(start_date=naive_start, end_date=naive_end)
     assert len(history) == 1
@@ -144,7 +145,7 @@ def test_get_label_print_history_filters_out_of_range_dates(tmp_path):
     manager = StatsManager(str(tmp_path))
     manager.record_label_print(client_id="M", sku="SKU-1", copies=1)
 
-    far_future_start = datetime.now() + timedelta(days=30)
+    far_future_start = datetime.now() + timedelta(days=30)  # noqa: DTZ005 -- naive input, same regression coverage as above
     history = manager.get_label_print_history(start_date=far_future_start)
     assert history == []
 

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,5 +1,13 @@
 import pytest
-from shared.theme import ThemeTokens, LIGHT_THEME, DARK_THEME, THEMES, get_theme, validate_theme, clamp_geometry
+
+from shared.theme import (
+    DARK_THEME,
+    LIGHT_THEME,
+    ThemeTokens,
+    clamp_geometry,
+    get_theme,
+    validate_theme,
+)
 
 
 def test_light_and_dark_themes_have_distinct_backgrounds():


### PR DESCRIPTION
## Summary
- Adds `ruff.toml` with repo-wide defaults plus two narrow, justified carve-outs: `BLE001` (broad-except) for the boundary sites this warehouse-floor GUI relies on not to crash, and an immutable-call allowance for Qt's `QModelIndex()` sentinel.
- Wires `ruff check .` into CI (`.github/workflows/build-release.yml`) as a blocking step ahead of the build, covering `shared/` as well — not excluded.
- Fixes every existing violation so the gate starts green, including `shared/`'s (previously unlinted, 57 violations).
- Split into 3 commits for reviewability: mechanical fixes → gate itself → the two fixes that needed real code (not just autofix).

## Commits
1. `style: ruff-driven mechanical lint cleanup across src/tests/shared` — PEP 604/585 type hints, import sorting, `IOError`→`OSError`, combined `with` statements, logged except blocks, etc. Behavior-preserving; verified by full test suite.
2. `ci: add blocking ruff lint gate` — `ruff.toml`, `ruff~=0.16.0` pin in `requirements-dev.txt`, CI step. Note: this commit's tree alone doesn't pass `ruff check .` — two violations (`TRY002` bare-`Exception` raise, one `F841`) have no auto-fix and are resolved in the next commit.
3. `fix: add SessionAlreadyActiveError and verify lock heartbeat actually updates` — replaces a bare `raise Exception(...)` with a real `SessionAlreadyActiveError`, and strengthens `test_reacquiring_own_lock_succeeds_and_updates_heartbeat`, which asserted `acquire_lock()` succeeded but never actually checked that the heartbeat updates.

## shared/ cross-repo note
`shared/` here is the canonical source, one-way-synced into `../shopify-fulfillment-tool`. The same lint fixes have already been synced into that repo via its `scripts/sync_shared.py`, and its own 196-test suite passes against the updated `shared/`. That repo's own commit/PR for those changes is handled separately.

## Test plan
- [x] `ruff check .` passes clean on the final tree
- [x] `python -m pytest tests/ -q` — 150 passed
- [x] `python -m py_compile` on all touched modules
- [x] shopify-fulfillment-tool's own test suite (196 passed) re-run after the `shared/` sync, to confirm no cross-repo regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash-safe saving so failed writes no longer corrupt existing session/stats files.
  * Strengthened session file locking and cleanup, including more reliable handling of unlock failures.
  * Enhanced error reporting across the app with clearer stack traces.
  * Improved timezone handling for timestamps and “Completed At” calculations.
* **Chores**
  * Added automated lint checking to the build process.
  * Modernized type hints and updated logging/time handling for consistency.
  * Expanded regression tests for atomic write recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->