### PR TITLE
Record packed order numbers for the Shopify tool's repeat detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ test_*.log
 
 # graphify skill output
 /graphify-out/
+
+# Local virtualenv (worktrees symlink the main checkout's)
+.venv
+.venv/

--- a/src/main.py
+++ b/src/main.py
@@ -1765,7 +1765,14 @@ class MainWindow(QMainWindow):
                     try:
                         if _cur_sess_path and _cur_pack_list:
                             _sess_mgr.update_session_metadata(
-                                _cur_sess_path, _cur_pack_list, 'completed'
+                                _cur_sess_path,
+                                _cur_pack_list,
+                                'completed',
+                                completed_orders=list(
+                                    _logic_ref.session_packing_state.get(
+                                        'completed_orders', []
+                                    )
+                                ) if _logic_ref else None,
                             )
                             logger.info("Updated session metadata to 'completed'")
                     except Exception as exc:

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -29,6 +29,7 @@ from pathlib import Path  # Modern path handling
 
 from exceptions import SessionAlreadyActiveError, SessionLockedError, StaleLockError
 from shared.atomic_write import atomic_write_json
+from shared.file_lock import locked_file
 from shared.metadata_utils import get_current_timestamp
 
 # Initialize module-level logger
@@ -668,7 +669,13 @@ class SessionManager:
         # 6. Return work directory path
         return work_dir
 
-    def update_session_metadata(self, session_path: str, packing_list_name: str, status: str):
+    def update_session_metadata(
+        self,
+        session_path: str,
+        packing_list_name: str,
+        status: str,
+        completed_orders: list[str] | None = None,
+    ):
         """
         Update Shopify session metadata with packing progress.
 
@@ -679,6 +686,10 @@ class SessionManager:
             session_path: Path to Shopify session
             packing_list_name: Name of packing list
             status: Status ('in_progress', 'completed', 'paused')
+            completed_orders: Order numbers packed in this session, if any.
+                The Shopify tool reads these back for repeat-order detection.
+                Merged with any already recorded, so resuming a session does
+                not drop orders packed before the resume.
         """
         session_info_file = Path(session_path) / SESSION_INFO_FILE
 
@@ -687,26 +698,32 @@ class SessionManager:
             return
 
         try:
-            # Load existing session info
-            with open(session_info_file, 'r', encoding='utf-8') as f:
-                session_info = json.load(f)
+            # The Shopify tool guards this same file with an exclusive lock on
+            # the sidecar .lock (its SessionManager._locked_session_info). Take
+            # the same lock: without it, its read-modify-write and ours can
+            # interleave and silently drop one side's changes.
+            lock_path = session_info_file.with_name(SESSION_INFO_FILE + ".lock")
+            with open(lock_path, "a+") as lock_handle, locked_file(lock_handle):
+                with open(session_info_file, 'r', encoding='utf-8') as f:
+                    session_info = json.load(f)
 
-            # Add packing progress section if not exists
-            if 'packing_progress' not in session_info:
-                session_info['packing_progress'] = {}
+                if 'packing_progress' not in session_info:
+                    session_info['packing_progress'] = {}
 
-            # Update for this packing list
-            if packing_list_name not in session_info['packing_progress']:
-                session_info['packing_progress'][packing_list_name] = {
-                    'started_at': get_current_timestamp(),
-                    'status': status
-                }
-            else:
-                session_info['packing_progress'][packing_list_name]['status'] = status
-                session_info['packing_progress'][packing_list_name]['updated_at'] = get_current_timestamp()
+                block = session_info['packing_progress'].setdefault(
+                    packing_list_name, {'started_at': get_current_timestamp()}
+                )
+                block['status'] = status
+                block['updated_at'] = get_current_timestamp()
 
-            # Save updated session info atomically (temp → move)
-            atomic_write_json(session_info_file, session_info, indent=2, ensure_ascii=False)
+                if completed_orders:
+                    merged = list(block.get('completed_orders', []))
+                    merged.extend(o for o in completed_orders if o not in merged)
+                    block['completed_orders'] = merged
+
+                atomic_write_json(
+                    session_info_file, session_info, indent=2, ensure_ascii=False
+                )
 
             logger.info(f"Updated session metadata: {packing_list_name} -> {status}")
 

--- a/tests/test_session_lock_manager.py
+++ b/tests/test_session_lock_manager.py
@@ -58,7 +58,15 @@ def test_acquire_lock_creates_lock_file(lock_manager, session_dir):
 def test_reacquiring_own_lock_succeeds_and_updates_heartbeat(lock_manager, session_dir):
     lock_manager.acquire_lock("M", session_dir)
     lock_path = session_dir / SessionLockManager.LOCK_FILENAME
-    original_heartbeat = json.loads(lock_path.read_text(encoding="utf-8"))["heartbeat"]
+
+    # Backdate the heartbeat rather than trusting the wall clock to tick between two
+    # acquire_lock() calls: datetime.now() is ~15.6ms-granular on Windows (CI), so a
+    # genuinely rewritten heartbeat can come back byte-identical to the previous one.
+    # 60s is well inside STALE_TIMEOUT (120s), so this stays a live lock, not a stale one.
+    data = json.loads(lock_path.read_text(encoding="utf-8"))
+    original_heartbeat = (datetime.now().astimezone() - timedelta(seconds=60)).isoformat()
+    data["heartbeat"] = original_heartbeat
+    lock_path.write_text(json.dumps(data), encoding="utf-8")
 
     success, error, _info = lock_manager.acquire_lock("M", session_dir)
     assert success is True

--- a/tests/test_session_metadata_orders.py
+++ b/tests/test_session_metadata_orders.py
@@ -81,3 +81,75 @@ def test_missing_session_info_does_not_raise(tmp_path):
         str(tmp_path), "ALL_ORDERS", "completed", completed_orders=["#A"]
     )
     assert not (tmp_path / "session_info.json").exists()
+
+
+def test_write_happens_inside_the_sidecar_lock(tmp_path, monkeypatch):
+    """The Shopify tool guards this same file with an exclusive lock on the
+    sidecar .lock. Without taking it here, its read-modify-write and ours
+    interleave and one side's order numbers are silently lost. This pins both
+    that the lock is taken and that the write happens inside it."""
+    import contextlib
+
+    import session_manager as sm
+
+    events = []
+    real_locked_file = sm.locked_file
+    real_atomic_write = sm.atomic_write_json
+
+    @contextlib.contextmanager
+    def spy_locked_file(handle, *args, **kwargs):
+        events.append(("lock_acquired", handle.name))
+        with real_locked_file(handle, *args, **kwargs):
+            yield
+        events.append(("lock_released", handle.name))
+
+    def spy_atomic_write(path, *args, **kwargs):
+        events.append(("write", str(path)))
+        return real_atomic_write(path, *args, **kwargs)
+
+    monkeypatch.setattr(sm, "locked_file", spy_locked_file)
+    monkeypatch.setattr(sm, "atomic_write_json", spy_atomic_write)
+
+    _seed_session_info(tmp_path)
+    _mgr().update_session_metadata(
+        str(tmp_path), "ALL_ORDERS", "completed", completed_orders=["#1"]
+    )
+
+    names = [e[0] for e in events]
+    assert names == ["lock_acquired", "write", "lock_released"], events
+    assert events[0][1].endswith("session_info.json.lock")
+
+
+def test_lock_guards_the_read_too_not_just_the_write(tmp_path, monkeypatch):
+    """A lock taken only around the write still loses updates: two callers
+    read the same snapshot first. Pin that the read is inside the lock."""
+    import contextlib
+
+    import session_manager as sm
+
+    events = []
+    real_locked_file = sm.locked_file
+    real_open = open
+
+    @contextlib.contextmanager
+    def spy_locked_file(handle, *args, **kwargs):
+        events.append("lock_acquired")
+        with real_locked_file(handle, *args, **kwargs):
+            yield
+        events.append("lock_released")
+
+    def spy_open(path, *args, **kwargs):
+        if str(path).endswith("session_info.json"):
+            events.append("read")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(sm, "locked_file", spy_locked_file)
+    monkeypatch.setattr("builtins.open", spy_open)
+
+    _seed_session_info(tmp_path)
+    _mgr().update_session_metadata(
+        str(tmp_path), "ALL_ORDERS", "completed", completed_orders=["#1"]
+    )
+
+    assert events.index("lock_acquired") < events.index("read")
+    assert events.index("read") < events.index("lock_released")

--- a/tests/test_session_metadata_orders.py
+++ b/tests/test_session_metadata_orders.py
@@ -1,0 +1,83 @@
+import json
+
+from session_manager import SessionManager
+
+
+def _mgr():
+    return SessionManager(
+        client_id="ALMADERM",
+        profile_manager=None,
+        lock_manager=None,
+        worker_id="worker_001",
+        worker_name="test",
+    )
+
+
+def _seed_session_info(tmp_path):
+    (tmp_path / "session_info.json").write_text(
+        json.dumps({"session_name": "2026-08-18_1", "client_id": "ALMADERM"}),
+        encoding="utf-8",
+    )
+
+
+def _read(tmp_path):
+    return json.loads((tmp_path / "session_info.json").read_text(encoding="utf-8"))
+
+
+def test_completed_orders_are_recorded(tmp_path):
+    _seed_session_info(tmp_path)
+
+    _mgr().update_session_metadata(
+        str(tmp_path), "ALL_ORDERS", "completed",
+        completed_orders=["#11019512", "#11019513"],
+    )
+
+    block = _read(tmp_path)["packing_progress"]["ALL_ORDERS"]
+    assert block["completed_orders"] == ["#11019512", "#11019513"]
+    assert block["status"] == "completed"
+
+
+def test_call_without_orders_still_works(tmp_path):
+    """Pre-existing three-argument callers must keep working."""
+    _seed_session_info(tmp_path)
+
+    _mgr().update_session_metadata(str(tmp_path), "ALL_ORDERS", "in_progress")
+
+    block = _read(tmp_path)["packing_progress"]["ALL_ORDERS"]
+    assert block["status"] == "in_progress"
+    assert "completed_orders" not in block
+
+
+def test_orders_are_merged_not_replaced_across_calls(tmp_path):
+    """A resumed session must not lose orders packed before the resume."""
+    _seed_session_info(tmp_path)
+    mgr = _mgr()
+
+    mgr.update_session_metadata(
+        str(tmp_path), "ALL_ORDERS", "completed", completed_orders=["#A"]
+    )
+    mgr.update_session_metadata(
+        str(tmp_path), "ALL_ORDERS", "completed", completed_orders=["#B"]
+    )
+
+    block = _read(tmp_path)["packing_progress"]["ALL_ORDERS"]
+    assert sorted(block["completed_orders"]) == ["#A", "#B"]
+
+
+def test_other_keys_in_session_info_are_preserved(tmp_path):
+    _seed_session_info(tmp_path)
+
+    _mgr().update_session_metadata(
+        str(tmp_path), "ALL_ORDERS", "completed", completed_orders=["#A"]
+    )
+
+    data = _read(tmp_path)
+    assert data["session_name"] == "2026-08-18_1"
+    assert data["client_id"] == "ALMADERM"
+
+
+def test_missing_session_info_does_not_raise(tmp_path):
+    _mgr().update_session_metadata(
+        str(tmp_path), "ALL_ORDERS", "completed", completed_orders=["#A"]
+    )
+    assert not (tmp_path / "session_info.json").exists()


### PR DESCRIPTION
## Summary

Producer half of a two-repo change. Packing Tool now records **which order numbers it finished packing** into the `packing_progress` block of the session's `session_info.json`, so the Shopify Fulfillment Tool can count a packed order as a prior sighting when it flags repeat orders.

Consumer PR (Shopify Fulfillment Tool): **https://github.com/cognitiveghost/shopify-fulfillment-tool/pull/290** — read that one for the design and the reason the change exists. This PR is inert without it, but harmless: nothing in Packing Tool reads the new key back.

## What changed

- **`src/session_manager.py` — `update_session_metadata()`** gains an optional `completed_orders` kwarg. When given, the order numbers are **merged** into the block rather than replacing it, so resuming a session does not drop orders packed before the resume.
- **The read-modify-write now takes the sidecar `.lock`** (`shared/file_lock.locked_file` on `session_info.json.lock`). The Shopify tool has always guarded this same file with an exclusive lock on that sidecar (`SessionManager._locked_session_info`); Packing Tool did not. Without it the two tools' read-modify-write cycles can interleave and silently drop one side's changes. Closing that gap was part of this task, not a drive-by.
- **`src/main.py`** — only the `'completed'` call site passes `completed_orders`. The two `'in_progress'` call sites are untouched.

## Compatibility

- `completed_orders` is an **additive, optional** key. An older Shopify Fulfillment Tool that does not know about it ignores it; a newer one treats its absence as "nothing packed". The two PRs can merge in either order and warehouse PCs can run mismatched versions safely.
- Order numbers are written in the same form Packing Tool already matches against `df['Order_Number']` (`src/main.py:856`, `:1648`), which is the column the Shopify tool exports — so both sides speak one format.

## Tests

`tests/test_session_metadata_orders.py` — 5 new tests covering: orders recorded on completion, merge-not-replace across repeated calls, no-op when the kwarg is omitted, and the existing status/timestamp behaviour left intact.

Pre-existing `tests/test_metadata_utils.py` (which pins the 3-positional-arg call signature and tz-aware timestamps) passes unmodified — the new parameter is keyword-only in practice and optional.

**Gate:** `155 passed` (150 baseline + 5). `ruff check` clean on the changed files.

## What code review changed

The new tests would have passed identically if `locked_file(...)` were deleted from `session_manager.py` — the load-bearing half of this change had no coverage, and a lost update here now costs order numbers rather than a status string. Two tests added in `b8252da`: one pinning that the write happens between lock acquire and release on `session_info.json.lock`, one pinning that the **read** is inside the lock too (a lock around the write alone still loses updates — both callers read the same snapshot first). Both fail when the `locked_file()` call is removed.

## Known, deliberately not fixed here

- `shared/file_lock.locked_file` raises `FileLockError` after 5 seconds, and the surrounding `except Exception` (`src/session_manager.py:730`) downgrades that to a warning. So under sustained contention this silently drops that session's `completed_orders`. The plan accepted this — recording it here so it isn't rediscovered later as a mystery.
- **Unrelated one-liner included:** `.gitignore` had no `.venv` entry (unlike the Shopify tool's), so the worktree's `.venv` symlink shows up as untracked and is trivially swept into a commit by `git add -A`. Added, because it will otherwise keep happening.

## Blocking issue lives in the consumer PR

The Shopify tool reads these order numbers out of a cache that nothing invalidates when this tool writes `session_info.json`, so the signal currently never arrives. That is a decision for **#290**, not this PR — nothing here changes either way. This PR is safe to merge on its own; it just has no effect until that is resolved.
