### PR TITLE
Phase 8.2: expand ThemeTokens to the design-system vocabulary, and enforce contrast

### DIFF
--- a/shared/theme.py
+++ b/shared/theme.py
@@ -22,7 +22,7 @@ class ThemeTokens:
     """Color/spacing/font tokens for one theme (light or dark).
 
     Color field names are kept identical to shopify-fulfillment-tool's
-    pre-unification `ThemeColors` dataclass on purpose -- ~180 call sites
+    pre-unification `ThemeColors` dataclass on purpose — ~180 call sites
     across gui/*.py read these by exact attribute name (e.g.
     `theme.text_secondary`, `theme.accent_blue`) and renaming them would
     mean touching every one of those call sites for no functional gain.
@@ -110,6 +110,9 @@ LIGHT_THEME = ThemeTokens(
     name="light",
     surface="#FFFFFF",
     surface_raised="#F4F4F5",
+    # Binding plane for light: text_placeholder lands at 4.50 and status_info at
+    # 4.52 against this, both within 0.05 of their floors. Darkening it fails
+    # validate_theme -- retune those two tokens with it, not after.
     surface_overlay="#EAEAEC",
     text="#1A1A1A",
     text_secondary="#5A5A5A",
@@ -235,6 +238,9 @@ _ALIAS_PAIRS = (
 # Text floors are AAA for body and AA for secondary; 3.0 is WCAG's non-text
 # minimum, applied to disabled text as well because a warehouse operator who
 # cannot read a disabled control files a support ticket.
+# Deliberately mirrored by a parametrized test in packing-tool's
+# tests/test_theme.py: the copy there is what catches someone *weakening* a
+# floor here. Keep both in step when adding a token.
 _MIN_CONTRAST_ON_PLANES = {
     "text": 7.0,
     "text_secondary": 4.5,
@@ -300,6 +306,10 @@ def validate_theme(theme: ThemeTokens) -> None:
                 f"tint {tint}, below the 4.5:1 minimum"
             )
 
+    # ponytail: on_accent is proven against accent_fill only. QPushButton:hover
+    # and :pressed swap button_hover_light/dark in behind the same white text;
+    # dark's #2D9FE8 is 2.90:1. Re-value in 8.3, when the five literal `white`s
+    # become on_accent and this pairing starts claiming to be covered.
     on_accent = contrast_ratio(theme.on_accent, theme.accent_fill)
     if on_accent < 4.5:
         raise ValueError(

--- a/shared/theme.py
+++ b/shared/theme.py
@@ -22,71 +22,166 @@ class ThemeTokens:
     """Color/spacing/font tokens for one theme (light or dark).
 
     Color field names are kept identical to shopify-fulfillment-tool's
-    pre-unification `ThemeColors` dataclass on purpose — ~180 call sites
+    pre-unification `ThemeColors` dataclass on purpose -- ~180 call sites
     across gui/*.py read these by exact attribute name (e.g.
     `theme.text_secondary`, `theme.accent_blue`) and renaming them would
     mean touching every one of those call sites for no functional gain.
+
+    Phase 8.2 therefore adds the design-system vocabulary alongside the old
+    names rather than replacing them: `background`, `background_elevated`,
+    `accent_*`, `active_*` are now aliases carrying the same literal as
+    their canonical token (see `_ALIAS_PAIRS`). `validate_theme` asserts
+    the pairs stay equal, so the duplication cannot drift.
+
+    No color field carries a default. The light-mode WCAG failure this
+    phase repairs was caused by `accent_*` being defaults that neither
+    theme overrode, so both themes rendered identical status colors on
+    opposite backgrounds. Every color is spelled out per theme; only the
+    theme-independent `spacing_*` / `radius_*` / `font_*` scales default.
     """
     name: str
-    background: str
-    background_elevated: str
+
+    # --- Surfaces: a real three-step elevation scale (spec 3.1) ---
+    surface: str
+    surface_raised: str
+    surface_overlay: str
+
+    # --- Text (spec 3.2) ---
     text: str
     text_secondary: str
     text_disabled: str
     text_placeholder: str
+
+    # --- Borders: the missing middle (spec 3.3) ---
     border: str
     border_subtle: str
+    border_strong: str
+
+    # --- Status roles, foreground + tint (spec 3.4) ---
+    status_info: str
+    status_info_bg: str
+    status_success: str
+    status_success_bg: str
+    status_warning: str
+    status_warning_bg: str
+    status_danger: str
+    status_danger_bg: str
+
+    # --- Solid accent fill; on_accent is the text that sits on it (spec 3.4a) ---
+    accent_fill: str
+    on_accent: str
+
+    # --- Selection and focus (spec 3.5) ---
+    selection_border: str
+    selection_bg: str
+    focus_ring: str
+
+    # --- Unchanged interaction colors ---
     hover: str
-    active_background: str
-    active_border: str
     button_hover_light: str
     button_hover_dark: str
-    accent_blue: str = "#007ACC"
-    accent_green: str = "#4CAF50"
-    accent_orange: str = "#FF9800"
-    accent_red: str = "#F44336"
+
+    # --- Aliases: same literal as the canonical token, see _ALIAS_PAIRS ---
+    background: str
+    background_elevated: str
+    accent_blue: str
+    accent_green: str
+    accent_orange: str
+    accent_red: str
+    active_background: str
+    active_border: str
+
+    # --- Theme-independent scales ---
     radius: int = 4
+    radius_sm: int = 3
+    radius_md: int = 6
+    radius_lg: int = 10
     spacing_xs: int = 4
     spacing_sm: int = 8
     spacing_md: int = 12
     spacing_lg: int = 16
     spacing_xl: int = 24
+    spacing_2xl: int = 32
     font_family: str = "Segoe UI, sans-serif"
     font_family_mono: str = "Consolas, monospace"
 
 
 LIGHT_THEME = ThemeTokens(
     name="light",
-    background="#FFFFFF",
-    background_elevated="#FAFAFA",
+    surface="#FFFFFF",
+    surface_raised="#F4F4F5",
+    surface_overlay="#EAEAEC",
     text="#1A1A1A",
     text_secondary="#5A5A5A",
-    text_disabled="#AAAAAA",
-    text_placeholder="#888888",
-    border="#1A1A1A",
-    border_subtle="#CCCCCC",
+    text_disabled="#808080",
+    text_placeholder="#6A6A6A",
+    border="#868686",
+    border_subtle="#D8D8D8",
+    border_strong="#1A1A1A",
+    status_info="#006DB7",
+    status_info_bg="#E3F2FD",
+    status_success="#347736",
+    status_success_bg="#EAF6EA",
+    status_warning="#995B00",
+    status_warning_bg="#FDF2E3",
+    status_danger="#D0190B",
+    status_danger_bg="#FDE4E3",
+    accent_fill="#006FBA",
+    on_accent="#FFFFFF",
+    selection_border="#006DB7",
+    selection_bg="#E3F2FD",
+    focus_ring="#0064AB",
     hover="#EEEEEE",
-    active_background="#F0F8F0",
-    active_border="#4CAF50",
     button_hover_light="#005A9E",
     button_hover_dark="#005A9E",
+    # aliases
+    background="#FFFFFF",
+    background_elevated="#F4F4F5",
+    accent_blue="#006FBA",
+    accent_green="#347736",
+    accent_orange="#995B00",
+    accent_red="#D0190B",
+    active_background="#E3F2FD",
+    active_border="#006DB7",
 )
 
 DARK_THEME = ThemeTokens(
     name="dark",
-    background="#000000",
-    background_elevated="#0F0F0F",
-    text="#FFFFFF",
+    surface="#0A0A0A",
+    surface_raised="#17171A",
+    surface_overlay="#232327",
+    text="#F2F2F2",
     text_secondary="#B0B0B0",
-    text_disabled="#444444",
-    text_placeholder="#888888",
-    border="#FFFFFF",
-    border_subtle="#404040",
+    text_disabled="#6E6E6E",
+    text_placeholder="#8A8A8A",
+    border="#6D6D6D",
+    border_subtle="#2E2E2E",
+    border_strong="#F2F2F2",
+    status_info="#008EEE",
+    status_info_bg="#042134",
+    status_success="#4CAF50",
+    status_success_bg="#112712",
+    status_warning="#FF9800",
+    status_warning_bg="#342104",
+    status_danger="#F54E42",
+    status_danger_bg="#340704",
+    accent_fill="#006FBA",
+    on_accent="#FFFFFF",
+    selection_border="#008EEE",
+    selection_bg="#042134",
+    focus_ring="#4DA9E8",
     hover="#1A1A1A",
-    active_background="#1A3D1A",
-    active_border="#4CAF50",
     button_hover_light="#2D9FE8",
     button_hover_dark="#2D9FE8",
+    # aliases
+    background="#0A0A0A",
+    background_elevated="#17171A",
+    accent_blue="#006FBA",
+    accent_green="#4CAF50",
+    accent_orange="#FF9800",
+    accent_red="#F54E42",
+    active_background="#042134",
+    active_border="#008EEE",
 )
 
 THEMES: dict = {"light": LIGHT_THEME, "dark": DARK_THEME}
@@ -98,12 +193,41 @@ def get_theme(name: str) -> ThemeTokens:
 
 
 _HEX_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
+
+_SURFACE_PLANES = ("surface", "surface_raised", "surface_overlay")
+
 _COLOR_FIELDS = (
-    "background", "background_elevated", "text", "text_secondary",
-    "text_disabled", "text_placeholder", "border", "border_subtle",
-    "hover", "active_background", "active_border", "button_hover_light",
-    "button_hover_dark", "accent_blue", "accent_green", "accent_orange",
-    "accent_red",
+    # canonical
+    "surface", "surface_raised", "surface_overlay",
+    "text", "text_secondary", "text_disabled", "text_placeholder",
+    "border", "border_subtle", "border_strong",
+    "status_info", "status_info_bg",
+    "status_success", "status_success_bg",
+    "status_warning", "status_warning_bg",
+    "status_danger", "status_danger_bg",
+    "accent_fill", "on_accent",
+    "selection_border", "selection_bg", "focus_ring",
+    "hover", "button_hover_light", "button_hover_dark",
+    # aliases
+    "background", "background_elevated",
+    "accent_blue", "accent_green", "accent_orange", "accent_red",
+    "active_background", "active_border",
+)
+
+# Legacy name -> canonical token. Each pair carries the same literal in both
+# theme constructors; validate_theme asserts they stay equal so the
+# duplication cannot drift. Aliases are real dataclass fields, not
+# properties: a property would sit outside _COLOR_FIELDS and escape
+# validation entirely.
+_ALIAS_PAIRS = (
+    ("background", "surface"),
+    ("background_elevated", "surface_raised"),
+    ("accent_blue", "accent_fill"),
+    ("accent_green", "status_success"),
+    ("accent_orange", "status_warning"),
+    ("accent_red", "status_danger"),
+    ("active_background", "selection_bg"),
+    ("active_border", "selection_border"),
 )
 
 
@@ -114,6 +238,14 @@ def validate_theme(theme: ThemeTokens) -> None:
         if not _HEX_RE.match(value):
             raise ValueError(
                 f"{theme.name}.{field_name} = {value!r} is not a valid #RRGGBB color"
+            )
+
+    for alias, canonical in _ALIAS_PAIRS:
+        if getattr(theme, alias) != getattr(theme, canonical):
+            raise ValueError(
+                f"{theme.name}.{alias} = {getattr(theme, alias)!r} has drifted "
+                f"from its canonical token {canonical} = "
+                f"{getattr(theme, canonical)!r}"
             )
 
 

--- a/shared/theme.py
+++ b/shared/theme.py
@@ -117,6 +117,28 @@ def validate_theme(theme: ThemeTokens) -> None:
             )
 
 
+def _relative_luminance(hex_color: str) -> float:
+    """WCAG 2.1 relative luminance of an #RRGGBB color."""
+    raw = hex_color.lstrip("#")
+    channels = [int(raw[i:i + 2], 16) / 255 for i in (0, 2, 4)]
+    linear = [
+        c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+        for c in channels
+    ]
+    return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+
+
+def contrast_ratio(fg: str, bg: str) -> float:
+    """WCAG 2.1 contrast ratio between two #RRGGBB colors, 1.0 to 21.0.
+
+    Symmetric in its arguments -- the names are for the caller's benefit.
+    """
+    lighter, darker = sorted(
+        (_relative_luminance(fg), _relative_luminance(bg)), reverse=True
+    )
+    return (lighter + 0.05) / (darker + 0.05)
+
+
 def clamp_geometry(
     x: int, y: int, w: int, h: int,
     avail_x: int, avail_y: int, avail_w: int, avail_h: int,

--- a/shared/theme.py
+++ b/shared/theme.py
@@ -231,8 +231,41 @@ _ALIAS_PAIRS = (
 )
 
 
+# token -> minimum contrast ratio against every plane in _SURFACE_PLANES.
+# Text floors are AAA for body and AA for secondary; 3.0 is WCAG's non-text
+# minimum, applied to disabled text as well because a warehouse operator who
+# cannot read a disabled control files a support ticket.
+_MIN_CONTRAST_ON_PLANES = {
+    "text": 7.0,
+    "text_secondary": 4.5,
+    "text_disabled": 3.0,
+    "text_placeholder": 4.5,
+    "border": 3.0,
+    "focus_ring": 3.0,
+    "selection_border": 3.0,
+    "status_info": 4.5,
+    "status_success": 4.5,
+    "status_warning": 4.5,
+    "status_danger": 4.5,
+}
+
+_STATUS_ROLES = ("info", "success", "warning", "danger")
+
+
 def validate_theme(theme: ThemeTokens) -> None:
-    """Raise ValueError if any color field isn't a valid #RRGGBB string."""
+    """Raise ValueError if a theme violates the 8.1 design-system contract.
+
+    Checks three things: every color field is a valid #RRGGBB string, every
+    alias still equals its canonical token, and every foreground clears its
+    WCAG minimum on all three surface planes -- not just on the window
+    background. The plane matrix is the point: light mode shipped three
+    status colors below AA for months because nothing ever measured them,
+    and a check against a single background per theme would have stayed
+    green throughout.
+
+    See docs/superpowers/specs/2026-08-25-phase8.1-design-system-design.md
+    section 6 in shopify-fulfillment-tool for the acceptance criterion.
+    """
     for field_name in _COLOR_FIELDS:
         value = getattr(theme, field_name)
         if not _HEX_RE.match(value):
@@ -247,6 +280,39 @@ def validate_theme(theme: ThemeTokens) -> None:
                 f"from its canonical token {canonical} = "
                 f"{getattr(theme, canonical)!r}"
             )
+
+    for token, floor in _MIN_CONTRAST_ON_PLANES.items():
+        value = getattr(theme, token)
+        for plane in _SURFACE_PLANES:
+            ratio = contrast_ratio(value, getattr(theme, plane))
+            if ratio < floor:
+                raise ValueError(
+                    f"{theme.name}.{token} has {ratio:.2f}:1 contrast against "
+                    f"{plane}, below the {floor}:1 minimum"
+                )
+
+    for role in _STATUS_ROLES:
+        fg, tint = f"status_{role}", f"status_{role}_bg"
+        ratio = contrast_ratio(getattr(theme, fg), getattr(theme, tint))
+        if ratio < 4.5:
+            raise ValueError(
+                f"{theme.name}.{fg} has {ratio:.2f}:1 contrast against its own "
+                f"tint {tint}, below the 4.5:1 minimum"
+            )
+
+    on_accent = contrast_ratio(theme.on_accent, theme.accent_fill)
+    if on_accent < 4.5:
+        raise ValueError(
+            f"{theme.name}.on_accent has {on_accent:.2f}:1 contrast against "
+            f"accent_fill, below the 4.5:1 minimum"
+        )
+
+    selected_text = contrast_ratio(theme.text, theme.selection_bg)
+    if selected_text < 4.5:
+        raise ValueError(
+            f"{theme.name}.text has {selected_text:.2f}:1 contrast against "
+            f"selection_bg, below the 4.5:1 minimum"
+        )
 
 
 def _relative_luminance(hex_color: str) -> float:

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -8,6 +8,7 @@ from shared.theme import (
     ThemeTokens,
     _ALIAS_PAIRS,
     _COLOR_FIELDS,
+    _SURFACE_PLANES,
     clamp_geometry,
     contrast_ratio,
     get_theme,
@@ -95,6 +96,59 @@ def test_validate_theme_rejects_a_drifted_alias():
     drifted = dataclasses.replace(LIGHT_THEME, name="drifted", accent_blue="#123456")
     with pytest.raises(ValueError, match="drifted from its canonical token"):
         validate_theme(drifted)
+
+
+@pytest.mark.parametrize("theme", [LIGHT_THEME, DARK_THEME], ids=["light", "dark"])
+@pytest.mark.parametrize("role", ["info", "success", "warning", "danger"])
+def test_status_foregrounds_clear_aa_on_every_plane_and_their_own_tint(theme, role):
+    """A badge has to be readable in a table, on a card and in a dialog
+    alike. A test built from a single background per theme would pass green
+    while every dialog failed AA -- which is what the spec's own first draft
+    did (spec 3.4)."""
+    fg = getattr(theme, f"status_{role}")
+    backgrounds = [getattr(theme, plane) for plane in _SURFACE_PLANES]
+    backgrounds.append(getattr(theme, f"status_{role}_bg"))
+    for bg in backgrounds:
+        assert contrast_ratio(fg, bg) >= 4.5, f"{theme.name} status_{role} on {bg}"
+
+
+@pytest.mark.parametrize("theme", [LIGHT_THEME, DARK_THEME], ids=["light", "dark"])
+@pytest.mark.parametrize("token,floor", [
+    ("text", 7.0),
+    ("text_secondary", 4.5),
+    ("text_disabled", 3.0),
+    ("text_placeholder", 4.5),
+    ("border", 3.0),
+    ("focus_ring", 3.0),
+    ("selection_border", 3.0),
+])
+def test_foreground_tokens_clear_their_floor_on_every_plane(theme, token, floor):
+    value = getattr(theme, token)
+    for plane in _SURFACE_PLANES:
+        ratio = contrast_ratio(value, getattr(theme, plane))
+        assert ratio >= floor, f"{theme.name}.{token} on {plane} = {ratio:.2f}"
+
+
+@pytest.mark.parametrize("theme", [LIGHT_THEME, DARK_THEME], ids=["light", "dark"])
+def test_on_accent_clears_aa_against_the_solid_fill(theme):
+    # shared/theme.py paints white on accent_blue in five places and
+    # build_palette pairs Highlight/HighlightedText the same way (spec 3.4a).
+    assert contrast_ratio(theme.on_accent, theme.accent_fill) >= 4.5
+
+
+@pytest.mark.parametrize("theme", [LIGHT_THEME, DARK_THEME], ids=["light", "dark"])
+def test_body_text_is_readable_on_a_selected_row(theme):
+    assert contrast_ratio(theme.text, theme.selection_bg) >= 4.5
+
+
+def test_validate_theme_rejects_a_status_colour_that_fails_on_a_dialog():
+    """The exact silent failure 8.2 exists to end: a value that passes on
+    the window background and fails on the overlay plane."""
+    # #0075EE is 4.51:1 on dark surface -- a pass -- but 3.56:1 on
+    # surface_overlay. A one-background check would call this fine.
+    sunk = dataclasses.replace(DARK_THEME, name="sunk", status_info="#0075EE")
+    with pytest.raises(ValueError, match="contrast"):
+        validate_theme(sunk)
 
 
 def test_clamp_geometry_leaves_window_untouched_when_it_fits():

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,14 +1,13 @@
-import pytest
-
 import dataclasses
 
+import pytest
+
 from shared.theme import (
+    _COLOR_FIELDS,
+    _SURFACE_PLANES,
     DARK_THEME,
     LIGHT_THEME,
     ThemeTokens,
-    _ALIAS_PAIRS,
-    _COLOR_FIELDS,
-    _SURFACE_PLANES,
     clamp_geometry,
     contrast_ratio,
     get_theme,

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,9 +1,13 @@
 import pytest
 
+import dataclasses
+
 from shared.theme import (
     DARK_THEME,
     LIGHT_THEME,
     ThemeTokens,
+    _ALIAS_PAIRS,
+    _COLOR_FIELDS,
     clamp_geometry,
     contrast_ratio,
     get_theme,
@@ -11,20 +15,60 @@ from shared.theme import (
 )
 
 
-def test_light_and_dark_themes_have_distinct_backgrounds():
-    assert LIGHT_THEME.background == "#FFFFFF"
-    assert DARK_THEME.background == "#000000"
+def test_dark_base_is_not_pure_black():
+    # Pure black gives elevation nowhere to go: every raised plane can only
+    # get lighter, and the first step reads as a smudge (spec 3.1).
+    assert DARK_THEME.surface == "#0A0A0A"
+    assert LIGHT_THEME.surface == "#FFFFFF"
 
 
-def test_light_theme_border_is_near_black_not_soft_gray():
-    # The approved design change: light theme borders mirror dark theme's
-    # crisp borders instead of the old #CCCCCC soft gray.
-    assert LIGHT_THEME.border == "#1A1A1A"
+def test_border_is_the_missing_middle_and_the_old_value_survives():
+    # border was pure text contrast (17.4:1) used for every box outline,
+    # which is what made both apps look harsh (spec 3.3).
+    assert LIGHT_THEME.border == "#868686"
+    assert DARK_THEME.border == "#6D6D6D"
+    assert LIGHT_THEME.border_strong == "#1A1A1A"
+    assert DARK_THEME.border_strong == "#F2F2F2"
 
 
-def test_both_themes_share_the_same_accent_and_radius():
-    assert LIGHT_THEME.accent_blue == DARK_THEME.accent_blue == "#007ACC"
-    assert LIGHT_THEME.radius == DARK_THEME.radius == 4
+def test_accent_blue_aliases_the_fill_not_the_info_foreground():
+    # A fill token sits behind white; a foreground token sits on a surface.
+    # One value cannot serve both -- aliasing accent_blue to status_info
+    # would ship every dark-mode primary button below AA (spec 3.4a).
+    for theme in (LIGHT_THEME, DARK_THEME):
+        assert theme.accent_blue == theme.accent_fill
+        assert theme.accent_blue != theme.status_info
+
+
+def test_status_colours_now_differ_per_theme():
+    # They were dataclass defaults, so both themes rendered identical status
+    # colours on opposite backgrounds -- the root cause of the light-mode
+    # failure (spec 1).
+    assert LIGHT_THEME.status_warning != DARK_THEME.status_warning
+    assert LIGHT_THEME.status_success != DARK_THEME.status_success
+
+
+def test_selection_no_longer_shares_a_value_with_success():
+    # active_border was #4CAF50, the same green as success. Selection and
+    # success are unrelated meanings; neither could be retuned (spec 3.5).
+    for theme in (LIGHT_THEME, DARK_THEME):
+        assert theme.selection_border != theme.status_success
+
+
+def test_radius_and_spacing_scales_exist():
+    assert (LIGHT_THEME.radius_sm, LIGHT_THEME.radius_md, LIGHT_THEME.radius_lg) == (3, 6, 10)
+    assert LIGHT_THEME.spacing_2xl == 32
+    assert LIGHT_THEME.radius == 4  # unchanged, still read by build_stylesheet
+
+
+def test_every_colour_field_is_declared_per_theme_not_defaulted():
+    """Spec 1's root cause: accent_* were dataclass defaults neither theme
+    overrode. A default on a colour field silently reintroduces that."""
+    defaulted = [
+        f.name for f in dataclasses.fields(ThemeTokens)
+        if f.name in _COLOR_FIELDS and f.default is not dataclasses.MISSING
+    ]
+    assert not defaulted, f"colour fields must not carry defaults: {defaulted}"
 
 
 def test_get_theme_returns_correct_instance():
@@ -42,15 +86,15 @@ def test_validate_theme_passes_for_both_builtin_themes():
 
 
 def test_validate_theme_rejects_bad_hex():
-    bad = ThemeTokens(
-        name="bad", background="not-a-color", background_elevated="#FFFFFF",
-        text="#000000", text_secondary="#000000", text_disabled="#000000",
-        text_placeholder="#000000", border="#000000", border_subtle="#000000",
-        hover="#000000", active_background="#000000", active_border="#000000",
-        button_hover_light="#000000", button_hover_dark="#000000",
-    )
-    with pytest.raises(ValueError):
+    bad = dataclasses.replace(LIGHT_THEME, name="bad", surface="not-a-color")
+    with pytest.raises(ValueError, match="not a valid #RRGGBB"):
         validate_theme(bad)
+
+
+def test_validate_theme_rejects_a_drifted_alias():
+    drifted = dataclasses.replace(LIGHT_THEME, name="drifted", accent_blue="#123456")
+    with pytest.raises(ValueError, match="drifted from its canonical token"):
+        validate_theme(drifted)
 
 
 def test_clamp_geometry_leaves_window_untouched_when_it_fits():

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -5,6 +5,7 @@ from shared.theme import (
     LIGHT_THEME,
     ThemeTokens,
     clamp_geometry,
+    contrast_ratio,
     get_theme,
     validate_theme,
 )
@@ -72,3 +73,20 @@ def test_clamp_geometry_pulls_window_back_onto_screen():
 def test_clamp_geometry_pulls_window_up_from_negative_position():
     result = clamp_geometry(-500, -500, 800, 600, 0, 0, 1920, 1080)
     assert result == (0, 0, 800, 600)
+
+
+def test_contrast_ratio_extremes():
+    assert contrast_ratio("#000000", "#FFFFFF") == pytest.approx(21.0, abs=0.01)
+    assert contrast_ratio("#FFFFFF", "#FFFFFF") == pytest.approx(1.0, abs=0.01)
+
+
+def test_contrast_ratio_is_symmetric():
+    assert contrast_ratio("#006DB7", "#FFFFFF") == pytest.approx(
+        contrast_ratio("#FFFFFF", "#006DB7")
+    )
+
+
+def test_contrast_ratio_matches_published_wcag_value():
+    # #767676 on #FFFFFF is the canonical 4.54:1 example in the WCAG 2.1
+    # docs -- if the sRGB linearisation is wrong this lands near 4.0 or 5.1.
+    assert contrast_ratio("#767676", "#FFFFFF") == pytest.approx(4.54, abs=0.01)


### PR DESCRIPTION
Phase 8.2 of the UI design-system rollout. **This is the canonical half** — `shared/` lives here, and `shopify-fulfillment-tool` machine-copies it. Merge this one first; the sibling PR's `shared-sync-check` job stays red until it lands.

Plan: `shopify-fulfillment-tool/docs/superpowers/plans/2026-08-25-phase8.2-token-expansion-plan.md`
Spec: Phase 8.1 §3 (merged)

## What changed

- `contrast_ratio()` — WCAG 2.1, in `shared/theme.py`.
- `ThemeTokens` grows the 8.1 vocabulary: three surface planes, a full text scale, status roles with tints, focus/selection tokens, plus theme-independent spacing/radius/font scales. Old field names are untouched — ~180 call sites read them by exact attribute name.
- `validate_theme()` now **raises** instead of returning findings, and checks every token against all three surface planes rather than `surface` alone.

## Two corrections to the spec, both verified by recomputation

The spec measured its text scale against `surface` only, then introduced raised and overlay planes without re-measuring. Two light values fail their own stated floors:

| token | spec value | surface | raised | overlay | floor |
|---|---|---|---|---|---|
| `text_disabled` | `#949494` | 3.03 | 2.76 ✗ | 2.52 ✗ | 3.0 |
| `text_placeholder` | `#767676` | 4.54 | 4.13 ✗ | 3.78 ✗ | 4.5 |

Shipped as `#808080` (3.95 / 3.59 / 3.29) and `#6A6A6A` (5.41 / 4.92 / 4.50). Dark's values already cleared all three planes and do not move.

## Deliberate design decisions

- **New colour fields carry no dataclass default.** The bug this phase exists to fix was `accent_*` defaults that neither theme overrode, so both themes shipped identical status colours on opposite backgrounds. A test asserts no colour field has a default.
- **The contrast matrix lives in `validate_theme`, not a test file.** `shopify-fulfillment-tool` has no `tests/test_theme.py` and `tests/` is not synced — putting the maths in the synced module means one implementation guards both repos. Safe to raise: the only callers are tests and the module's `__main__` self-check, never app startup.
- **Alias fields are duplicated literals guarded by an equality test**, not derived in `__post_init__` — which would silently overwrite an explicit value and make both the bad-hex and drifted-alias tests impossible to write.
- **Spec §4's px type tokens are excluded**, deferred to 8.5. A points-based `TYPE_SCALE` already exists in shopify's `gui/theme_manager.py` with an overlapping role set; adding px now installs a second scale in a different unit.

## Verification

192/192 tests pass, `ruff check .` clean.

## Review fixes applied

- `ruff check .` was failing on the new test file (CI here runs it with no exclusions).
- Recorded a **pre-existing** AA hole for 8.3: `on_accent` is validated against `accent_fill`, but `QPushButton:hover`/`:pressed` swap `button_hover_light`/`_dark` in behind the same white text — dark's `#2D9FE8` is 2.90:1. Out of scope to re-value here, but 8.3 would otherwise assume the pairing is covered.
- Noted that light `surface_overlay` is the binding plane (two tokens within 0.05 of their floor against it).

## Known gaps, not addressed here

`shopify_tool/tag_manager.py` and `profile_manager.py` hardcode user-overridable colours (`#4CAF50`, `#FF9800`, `#9E9E9E`) as data defaults. The matrix can never cover user-chosen colours, but light `#4CAF50` now visibly disagrees with light `status_success`. Worth an explicit "user-chosen colours are out of contract" decision in a later phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGMt34PtsinPgEWgSzMn9B